### PR TITLE
fix lscolors config if environment variable not set

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -28,7 +28,7 @@ use crate::widget::Events;
 
 
 lazy_static! {
-    static ref COLORS: LsColors = LsColors::from_env().unwrap();
+    static ref COLORS: LsColors = LsColors::from_env().unwrap_or_default();
     static ref TAGS: RwLock<(bool, Vec<PathBuf>)> = RwLock::new((false, vec![]));
 }
 


### PR DESCRIPTION
Per the lscolors crate docs, this switches from an `unwrap` to
`unwrap_or_default` so that this does not panic when this environment
variable is not set for the user, fixing a crash on startup in hunter.