### PR TITLE
Remove dependencies to nightly build of rust compiler.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,26 +1,8 @@
-extern crate termion;
 extern crate rustc_version;
-
-use rustc_version::{version_meta, Channel};
-
+extern crate termion;
 // use std::process::Command;
 
-
-fn main() -> Result<(),()> {
-    // Bail out if compiler isn't a nightly
-    if let Ok(false) = version_meta().map(|m| m.channel == Channel::Nightly) {
-        eprint!("{}", termion::color::Fg(termion::color::Red));
-        eprint!("{}", termion::style::Bold);
-        eprint!("{}", termion::style::Underline);
-        eprintln!("NIHGTLY COMPILER required");
-        eprintln!("Please install a nighlty compiler to proceed: https://rustup.rs/");
-        eprint!("{}", termion::style::Reset);
-        eprintln!("rustup toolchain install nightly");
-        eprintln!("source ~/.cargo/env");
-
-        return Err(());
-    }
-
+fn main() -> Result<(), ()> {
     // crates.io doesn't allow question marks in file names
     // So we just stuff that in an archive for distribution
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,12 @@
-use lazy_static;
 use clap;
+use lazy_static;
 
 use std::sync::RwLock;
 
 use crate::paths;
 
-use crate::fail::{HError, HResult, ErrorLog};
+use crate::fail::{ErrorLog, HError, HResult};
 use crate::keybind::KeyBinds;
-
 
 #[derive(Clone)]
 // These are options, so we know if they have been set or not
@@ -24,15 +23,14 @@ impl ArgvConfig {
             animation: None,
             show_hidden: None,
             icons: None,
-            graphics: None
+            graphics: None,
         }
     }
 }
 
 lazy_static! {
-    static ref ARGV_CONFIG: RwLock<ArgvConfig>  = RwLock::new(ArgvConfig::new());
+    static ref ARGV_CONFIG: RwLock<ArgvConfig> = RwLock::new(ArgvConfig::new());
 }
-
 
 pub fn set_argv_config(args: clap::ArgMatches) -> HResult<()> {
     let animation = args.is_present("animation-off");
@@ -66,7 +64,7 @@ pub fn set_argv_config(args: clap::ArgMatches) -> HResult<()> {
 }
 
 fn get_argv_config() -> HResult<ArgvConfig> {
-        Ok(ARGV_CONFIG.try_read()?.clone())
+    Ok(ARGV_CONFIG.try_read()?.clone())
 }
 
 fn infuse_argv_config(mut config: Config) -> Config {
@@ -93,11 +91,10 @@ pub struct Config {
     pub media_mute: bool,
     pub media_previewer: String,
     pub media_previewer_exists: bool,
-    pub ratios: Vec::<usize>,
+    pub ratios: Vec<usize>,
     pub graphics: String,
     pub keybinds: KeyBinds,
 }
-
 
 impl Config {
     pub fn new() -> Config {
@@ -119,7 +116,7 @@ impl Config {
             media_mute: false,
             media_previewer: "hunter-media".to_string(),
             media_previewer_exists: false,
-            ratios: vec![20,30,49],
+            ratios: vec![20, 30, 49],
             graphics: detect_g_mode(),
             keybinds: KeyBinds::default(),
         }
@@ -134,80 +131,84 @@ impl Config {
 
         let config_string = std::fs::read_to_string(config_path)?;
 
-        let config = config_string.lines().fold(Config::new(), |mut config, line| {
-            match Config::prep_line(line) {
-                Ok(("animation", "on")) => config.animation = true,
-                Ok(("animation", "off")) => config.animation = false,
-                Ok(("animation_refresh_frequency", frequency)) => {
-                    match frequency.parse::<usize>() {
-                        Ok(parsed_freq) => config.animation_refresh_frequency = parsed_freq,
-                        _ => HError::config_error::<Config>(line.to_string()).log()
+        let config = config_string
+            .lines()
+            .fold(Config::new(), |mut config, line| {
+                match Config::prep_line(line) {
+                    Ok(("animation", "on")) => config.animation = true,
+                    Ok(("animation", "off")) => config.animation = false,
+                    Ok(("animation_refresh_frequency", frequency)) => {
+                        match frequency.parse::<usize>() {
+                            Ok(parsed_freq) => config.animation_refresh_frequency = parsed_freq,
+                            _ => HError::config_error::<Config>(line.to_string()).log(),
+                        }
                     }
-                }
-                Ok(("show_hidden", "on")) => config.show_hidden = true,
-                Ok(("show_hidden", "off")) => config.show_hidden = false,
-                Ok(("icons", "on")) => config.icons = true,
-                Ok(("icons", "off")) => config.icons = false,
-                Ok(("icons_space", "on")) => config.icons_space = true,
-                Ok(("icons_space", "off")) => config.icons_space = false,
-                Ok(("select_cmd", cmd)) => {
-                    let cmd = cmd.to_string();
-                    config.select_cmd = cmd;
-                }
-                Ok(("cd_cmd", cmd)) => {
-                    let cmd = cmd.to_string();
-                    config.cd_cmd = cmd;
-                }
-                Ok(("media_autoplay", "on")) => config.media_autoplay = true,
-                Ok(("media_autoplay", "off")) => config.media_autoplay = false,
-                Ok(("media_mute", "on")) => config.media_mute = true,
-                Ok(("media_mute", "off")) => config.media_mute = false,
-                Ok(("media_previewer", cmd)) => {
-                    let cmd = cmd.to_string();
-                    config.media_previewer = cmd;
-                },
-                Ok(("ratios", ratios)) => {
-                    let ratios_str = ratios.to_string();
-                    if ratios_str.chars().all(|x| x.is_digit(10) || x.is_whitespace()
-                        || x == ':' || x == ',' ) {
-                        let ratios: Vec<usize> = ratios_str.split([',', ':'].as_ref())
-                            .map(|r| r.trim()
-                                 .parse().unwrap())
-                            .collect();
-                        let ratios_sum: usize = ratios.iter().sum();
-                        if ratios.len() == 3 && ratios_sum > 0 &&
-                            ratios
-                            .iter()
-                            .filter(|&r| *r > u16::max_value() as usize)
-                            .next() == None {
+                    Ok(("show_hidden", "on")) => config.show_hidden = true,
+                    Ok(("show_hidden", "off")) => config.show_hidden = false,
+                    Ok(("icons", "on")) => config.icons = true,
+                    Ok(("icons", "off")) => config.icons = false,
+                    Ok(("icons_space", "on")) => config.icons_space = true,
+                    Ok(("icons_space", "off")) => config.icons_space = false,
+                    Ok(("select_cmd", cmd)) => {
+                        let cmd = cmd.to_string();
+                        config.select_cmd = cmd;
+                    }
+                    Ok(("cd_cmd", cmd)) => {
+                        let cmd = cmd.to_string();
+                        config.cd_cmd = cmd;
+                    }
+                    Ok(("media_autoplay", "on")) => config.media_autoplay = true,
+                    Ok(("media_autoplay", "off")) => config.media_autoplay = false,
+                    Ok(("media_mute", "on")) => config.media_mute = true,
+                    Ok(("media_mute", "off")) => config.media_mute = false,
+                    Ok(("media_previewer", cmd)) => {
+                        let cmd = cmd.to_string();
+                        config.media_previewer = cmd;
+                    }
+                    Ok(("ratios", ratios)) => {
+                        let ratios_str = ratios.to_string();
+                        if ratios_str
+                            .chars()
+                            .all(|x| x.is_digit(10) || x.is_whitespace() || x == ':' || x == ',')
+                        {
+                            let ratios: Vec<usize> = ratios_str
+                                .split([',', ':'].as_ref())
+                                .map(|r| r.trim().parse().unwrap())
+                                .collect();
+                            let ratios_sum: usize = ratios.iter().sum();
+                            if ratios.len() == 3
+                                && ratios_sum > 0
+                                && ratios
+                                    .iter()
+                                    .filter(|&r| *r > u16::max_value() as usize)
+                                    .next()
+                                    == None
+                            {
                                 config.ratios = ratios;
                             }
+                        }
+                    }
+                    #[cfg(feature = "sixel")]
+                    Ok(("graphics", "sixel")) => config.graphics = "sixel".to_string(),
+                    Ok(("graphics", "kitty")) => config.graphics = "kitty".to_string(),
+                    Ok(("graphics", "auto")) => config.graphics = detect_g_mode(),
+                    _ => {
+                        HError::config_error::<Config>(line.to_string()).log();
                     }
                 }
-                #[cfg(feature = "sixel")]
-                Ok(("graphics",
-                    "sixel")) => config.graphics = "sixel".to_string(),
-                Ok(("graphics",
-                    "kitty")) => config.graphics = "kitty".to_string(),
-                Ok(("graphics",
-                    "auto")) => config.graphics = detect_g_mode(),
-                _ => { HError::config_error::<Config>(line.to_string()).log(); }
-            }
 
-            #[cfg(feature = "img")]
-            match has_media_previewer(&config.media_previewer) {
-                t @ _ => config.media_previewer_exists = t
-            }
+                #[cfg(feature = "img")]
+                match has_media_previewer(&config.media_previewer) {
+                    t @ _ => config.media_previewer_exists = t,
+                }
 
-            config
-        });
+                config
+            });
 
         let mut config = infuse_argv_config(config);
 
         //use std::iter::Extend;
-        KeyBinds::load()
-            .map(|kb| config.keybinds = kb)
-            .log();
+        KeyBinds::load().map(|kb| config.keybinds = kb).log();
 
         Ok(config)
     }
@@ -219,7 +220,6 @@ impl Config {
         } else {
             HError::config_error(line.to_string())
         }
-
     }
 
     pub fn animate(&self) -> bool {
@@ -241,8 +241,9 @@ fn detect_g_mode() -> String {
         "xterm-kitty" => "kitty",
         #[cfg(feature = "sixel")]
         "xterm" => "sixel",
-        _ => "unicode"
-    }.to_string()
+        _ => "unicode",
+    }
+    .to_string()
 }
 
 fn has_media_previewer(name: &str) -> bool {
@@ -250,6 +251,6 @@ fn has_media_previewer(name: &str) -> bool {
     let previewer = std::path::Path::new(name);
     match previewer.is_absolute() {
         true => previewer.exists(),
-        false => find_bins(name).is_ok()
+        false => find_bins(name).is_ok(),
     }
 }

--- a/src/config_installer.rs
+++ b/src/config_installer.rs
@@ -1,12 +1,11 @@
+use std::ffi::OsStr;
 use std::fs::*;
 use std::io::Write;
-use std::process::Command;
-use std::ffi::OsStr;
 use std::path::Path;
+use std::process::Command;
 
-use crate::fail::{HError, HResult, ErrorLog};
+use crate::fail::{ErrorLog, HError, HResult};
 use crate::widget::WidgetCore;
-
 
 pub fn ensure_config(core: WidgetCore) -> HResult<()> {
     if has_config()? {
@@ -16,31 +15,32 @@ pub fn ensure_config(core: WidgetCore) -> HResult<()> {
         if !previewers_path.exists() {
             core.show_status("Coulnd't find previewers in config dir! Adding!")?;
             install_config_previewers()
-                .or_else(|_|
-                         core.show_status("Error installing previewers! Check log!"))?;
+                .or_else(|_| core.show_status("Error installing previewers! Check log!"))?;
         }
 
         if !actions_path.exists() {
             core.show_status("Coulnd't find actions in config dir! Adding!")?;
             install_config_actions()
-                .or_else(|_|
-                         core.show_status("Error installing actions! Check log!"))?;
+                .or_else(|_| core.show_status("Error installing actions! Check log!"))?;
         }
 
         return Ok(());
     }
 
     let msg = match install_config_all() {
-        Ok(_) => format!("Config installed in: {}",
-                         crate::paths::hunter_path()?.to_string_lossy()),
-        Err(_) => format!("{}Problems with installation of default configuration! Look inside log.",
-                          crate::term::color_red()),
+        Ok(_) => format!(
+            "Config installed in: {}",
+            crate::paths::hunter_path()?.to_string_lossy()
+        ),
+        Err(_) => format!(
+            "{}Problems with installation of default configuration! Look inside log.",
+            crate::term::color_red()
+        ),
     };
     core.show_status(&msg)?;
 
     Ok(())
 }
-
 
 fn default_config_archive() -> &'static [u8] {
     let default_config = include_bytes!("../config.tar.gz");
@@ -57,17 +57,18 @@ fn has_config() -> HResult<bool> {
     }
 }
 
-
 fn install_config_all() -> HResult<()> {
     let hunter_dir = crate::paths::hunter_path()?;
-    let config_dir = hunter_dir.parent()?;
+    let config_dir = hunter_dir.parent().ok_or_else(|| HError::NoneError)?;
 
     if !hunter_dir.exists() {
         // create if non-existing
-        std::fs::create_dir(&hunter_dir)
-            .or_else(|_| HError::log(&format!("Couldn't create directory: {}",
-                                              hunter_dir.as_os_str()
-                                                        .to_string_lossy())))?;
+        std::fs::create_dir(&hunter_dir).or_else(|_| {
+            HError::log(&format!(
+                "Couldn't create directory: {}",
+                hunter_dir.as_os_str().to_string_lossy()
+            ))
+        })?;
     }
 
     let archive_path = create_archive()?;
@@ -87,9 +88,11 @@ fn copy(from: &Path, to: &Path) -> HResult<()> {
         .map(|s| s.success());
 
     if success.is_err() || !success.unwrap() {
-        HError::log(&format!("Couldn't copy {} to {} !",
-                             from.to_string_lossy(),
-                             to.to_string_lossy()))
+        HError::log(&format!(
+            "Couldn't copy {} to {} !",
+            from.to_string_lossy(),
+            to.to_string_lossy()
+        ))
     } else {
         Ok(())
     }
@@ -145,7 +148,7 @@ pub fn update_config(core: WidgetCore, force: bool) -> HResult<()> {
     if force {
         install_config_previewers().log();
         install_config_actions().log();
-        return Ok(())
+        return Ok(());
     }
 
     let archive_path = create_archive()?;
@@ -156,7 +159,7 @@ pub fn update_config(core: WidgetCore, force: bool) -> HResult<()> {
 fn update_dir<P: AsRef<Path>>(source: P, target: P) -> HResult<()> {
     for file in std::fs::read_dir(source)? {
         let file_path = file?.path();
-        let file_name = file_path.file_name()?;
+        let file_name = file_path.file_name().ok_or_else(|| HError::NoneError)?;
         let target_path = target.as_ref().join(file_name);
 
         if file_path.is_dir() {
@@ -164,8 +167,11 @@ fn update_dir<P: AsRef<Path>>(source: P, target: P) -> HResult<()> {
             update_dir(&file_path, &target_path).log();
         } else {
             if !target_path.exists() {
-                HError::log::<()>(&format!("Installing additional config file: {}",
-                                           file_path.to_string_lossy())).ok();
+                HError::log::<()>(&format!(
+                    "Installing additional config file: {}",
+                    file_path.to_string_lossy()
+                ))
+                .ok();
                 copy(&file_path, &target_path).log();
             }
         }
@@ -174,44 +180,49 @@ fn update_dir<P: AsRef<Path>>(source: P, target: P) -> HResult<()> {
     Ok(())
 }
 
-
 fn create_archive() -> HResult<&'static str> {
     let archive_path = "/tmp/hunter-config.tar.gz";
     let def_config = default_config_archive();
 
     File::create(archive_path)
-        .and_then(|mut f| {
-            f.write_all(def_config).map(|_| f)
-        })
+        .and_then(|mut f| f.write_all(def_config).map(|_| f))
         .and_then(|mut f| f.flush())
         .or_else(|_| {
-            HError::log(&format!("Failed to write config archive to: {}",
-                                 archive_path))
+            HError::log(&format!(
+                "Failed to write config archive to: {}",
+                archive_path
+            ))
         })?;
     Ok(archive_path)
 }
 
-
 fn extract_archive(to: &Path, archive_path: &str) -> HResult<()> {
     let success = Command::new("tar")
-        .args(&[OsStr::new("-C"),
-                to.as_os_str(),
-                OsStr::new("-xf"),
-                OsStr::new(archive_path)])
+        .args(&[
+            OsStr::new("-C"),
+            to.as_os_str(),
+            OsStr::new("-xf"),
+            OsStr::new(archive_path),
+        ])
         .status()
         .or_else(|_| HError::log(&format!("Couldn't run tar!")))
         .map(|s| s.success())?;
 
     if !success {
-        HError::log(&format!("Extraction of archive failed! Archive: {}",
-                             archive_path))?
+        HError::log(&format!(
+            "Extraction of archive failed! Archive: {}",
+            archive_path
+        ))?
     }
 
     Ok(())
 }
 
 fn delete_archive(archive_path: &str) -> HResult<()> {
-    std::fs::remove_file(archive_path)
-        .or_else(|_| HError::log(&format!("Deletion of archive failed! Archive: {}",
-                                          archive_path)))
+    std::fs::remove_file(archive_path).or_else(|_| {
+        HError::log(&format!(
+            "Deletion of archive failed! Archive: {}",
+            archive_path
+        ))
+    })
 }

--- a/src/coordinates.rs
+++ b/src/coordinates.rs
@@ -19,10 +19,10 @@ impl Coordinates {
         }
     }
 
-    pub fn new_at(xsize: u16, ysize: u16, xpos: u16, ypos: u16 ) -> Coordinates {
+    pub fn new_at(xsize: u16, ysize: u16, xpos: u16, ypos: u16) -> Coordinates {
         Coordinates {
             size: Size((xsize, ysize)),
-            position: Position((xpos, ypos))
+            position: Position((xpos, ypos)),
         }
     }
 
@@ -35,7 +35,7 @@ impl Coordinates {
     }
 
     pub fn set_size_u(&mut self, x: usize, y: usize) {
-        self.size.0 = ((x+1) as u16, (y+1) as u16);
+        self.size.0 = ((x + 1) as u16, (y + 1) as u16);
     }
 
     pub fn set_xsize(&mut self, x: u16) {
@@ -51,7 +51,7 @@ impl Coordinates {
     }
 
     pub fn set_position_u(&mut self, x: usize, y: usize) {
-        self.position.0 = ((x+1) as u16, (y+1) as u16);
+        self.position.0 = ((x + 1) as u16, (y + 1) as u16);
     }
 
     pub fn set_xpos(&mut self, x: u16) {
@@ -96,7 +96,7 @@ impl Coordinates {
 
     pub fn position_u(&self) -> (usize, usize) {
         let (xpos, ypos) = self.u16position();
-        ((xpos-1) as usize, (ypos-1) as usize)
+        ((xpos - 1) as usize, (ypos - 1) as usize)
     }
 
     pub fn size(&self) -> &Size {
@@ -109,7 +109,7 @@ impl Coordinates {
 
     pub fn size_u(&self) -> (usize, usize) {
         let (xsize, ysize) = self.u16size();
-        ((xsize-1) as usize, (ysize-1) as usize)
+        ((xsize - 1) as usize, (ysize - 1) as usize)
     }
 
     pub fn size_pixels(&self) -> HResult<(usize, usize)> {
@@ -117,10 +117,9 @@ impl Coordinates {
         let (cols, rows) = crate::term::size()?;
         let (xpix, ypix) = crate::term::size_pixels()?;
         // Cell dimensions
-        let (xpix, ypix) = (xpix/cols, ypix/rows);
+        let (xpix, ypix) = (xpix / cols, ypix / rows);
         // Frame dimensions
-        let (xpix, ypix) = (xpix * (xsize + 1),
-                            ypix * (ysize + 1));
+        let (xpix, ypix) = (xpix * (xsize + 1), ypix * (ysize + 1));
 
         Ok((xpix as usize, ypix as usize))
     }
@@ -138,7 +137,7 @@ impl Size {
     }
     pub fn size_u(&self) -> (usize, usize) {
         let (xsize, ysize) = self.0;
-        ((xsize-1) as usize, (ysize-1) as usize)
+        ((xsize - 1) as usize, (ysize - 1) as usize)
     }
     pub fn xsize(&self) -> u16 {
         (self.0).0
@@ -154,7 +153,7 @@ impl Position {
     }
     pub fn position_u(&self) -> (usize, usize) {
         let (xpos, ypos) = self.0;
-        ((xpos-1) as usize, (ypos-1) as usize)
+        ((xpos - 1) as usize, (ypos - 1) as usize)
     }
     pub fn x(&self) -> u16 {
         (self.0).0

--- a/src/dirty.rs
+++ b/src/dirty.rs
@@ -1,5 +1,5 @@
-use std::sync::{Arc, RwLock};
 use std::hash::{Hash, Hasher};
+use std::sync::{Arc, RwLock};
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub struct DirtyBit(bool);
@@ -33,7 +33,6 @@ pub trait Dirtyable {
     fn set_clean(&mut self);
 }
 
-
 impl DirtyBit {
     pub fn new() -> DirtyBit {
         DirtyBit(false)
@@ -45,7 +44,6 @@ impl AsyncDirtyBit {
         AsyncDirtyBit(Arc::new(RwLock::new(DirtyBit::new())))
     }
 }
-
 
 impl Dirtyable for DirtyBit {
     fn is_dirty(&self) -> bool {

--- a/src/fail.rs
+++ b/src/fail.rs
@@ -3,7 +3,6 @@ use failure::Fail;
 //use failure::Backtrace;
 //use async_value::AError;
 
-
 use termion::event::Key;
 
 use std::path::PathBuf;
@@ -14,8 +13,6 @@ use crate::mediaview::MediaError;
 
 pub type HResult<T> = Result<T, HError>;
 
-
-
 #[derive(Fail, Debug, Clone)]
 pub enum HError {
     #[fail(display = "IO error: {} ", _0)]
@@ -25,17 +22,23 @@ pub enum HError {
     #[fail(display = "Can't lock!")]
     TryLockError,
     #[fail(display = "Channel failed: {}", error)]
-    ChannelTryRecvError{#[cause] error: std::sync::mpsc::TryRecvError},
+    ChannelTryRecvError {
+        #[cause]
+        error: std::sync::mpsc::TryRecvError,
+    },
     #[fail(display = "Channel failed: {}", error)]
-    ChannelRecvError{#[cause] error: std::sync::mpsc::RecvError},
+    ChannelRecvError {
+        #[cause]
+        error: std::sync::mpsc::RecvError,
+    },
     #[fail(display = "Channel failed")]
     ChannelSendError,
     #[fail(display = "Timer ran out while waiting for message on channel!")]
     ChannelRecvTimeout(#[cause] std::sync::mpsc::RecvTimeoutError),
     #[fail(display = "Previewer failed on file: {}", file)]
-    PreviewFailed{file: String},
+    PreviewFailed { file: String },
     #[fail(display = "StalePreviewer for file: {}", file)]
-    StalePreviewError{file: String},
+    StalePreviewError { file: String },
     #[fail(display = "Accessed stale value")]
     StaleError,
     #[fail(display = "Failed: {}", _0)]
@@ -47,7 +50,7 @@ pub enum HError {
     #[fail(display = "No widget found")]
     NoWidgetError,
     #[fail(display = "Path: {:?} not in this directory: {:?}", path, dir)]
-    WrongDirectoryError{ path: PathBuf, dir: PathBuf},
+    WrongDirectoryError { path: PathBuf, dir: PathBuf },
     #[fail(display = "Widget finnished")]
     PopupFinnished,
     #[fail(display = "No completions found")]
@@ -60,18 +63,24 @@ pub enum HError {
     NoHeaderError,
     #[fail(display = "You wanted this!")]
     Quit,
-    #[fail(display = "HBox ratio mismatch: {} widgets, ratio is {:?}", wnum, ratio)]
-    HBoxWrongRatioError{ wnum: usize, ratio: Vec<usize> },
+    #[fail(
+        display = "HBox ratio mismatch: {} widgets, ratio is {:?}",
+        wnum, ratio
+    )]
+    HBoxWrongRatioError { wnum: usize, ratio: Vec<usize> },
     #[fail(display = "Got wrong widget: {}! Wanted: {}", got, wanted)]
-    WrongWidgetError{got: String, wanted: String},
+    WrongWidgetError { got: String, wanted: String },
     #[fail(display = "Strip Prefix Error: {}", error)]
-    StripPrefixError{#[cause] error: std::path::StripPrefixError},
+    StripPrefixError {
+        #[cause]
+        error: std::path::StripPrefixError,
+    },
     #[fail(display = "INofify failed: {}", _0)]
     INotifyError(String),
     #[fail(display = "Tags not loaded yet")]
     TagsNotLoadedYetError,
     #[fail(display = "Undefined key: {:?}", key)]
-    WidgetUndefinedKeyError{key: Key},
+    WidgetUndefinedKeyError { key: Key },
     #[fail(display = "Terminal has been resized!")]
     TerminalResizedError,
     #[fail(display = "Widget has been resized!")]
@@ -118,15 +127,19 @@ impl HError {
         Err(HError::Quit)
     }
     pub fn wrong_ratio<T>(wnum: usize, ratio: Vec<usize>) -> HResult<T> {
-        Err(HError::HBoxWrongRatioError{ wnum: wnum, ratio: ratio })
+        Err(HError::HBoxWrongRatioError {
+            wnum: wnum,
+            ratio: ratio,
+        })
     }
     pub fn no_widget<T>() -> HResult<T> {
         Err(HError::NoWidgetError)
     }
     pub fn wrong_widget<T>(got: &str, wanted: &str) -> HResult<T> {
-        Err(HError::WrongWidgetError{ got: got.to_string(),
-                                      wanted: wanted.to_string() })
-
+        Err(HError::WrongWidgetError {
+            got: got.to_string(),
+            wanted: wanted.to_string(),
+        })
     }
     pub fn popup_finnished<T>() -> HResult<T> {
         Err(HError::PopupFinnished)
@@ -138,14 +151,14 @@ impl HError {
         Err(HError::WidgetUndefinedKeyError { key: key })
     }
     pub fn wrong_directory<T>(path: PathBuf, dir: PathBuf) -> HResult<T> {
-        Err(HError::WrongDirectoryError{ path: path,
-                                         dir: dir })
-
+        Err(HError::WrongDirectoryError {
+            path: path,
+            dir: dir,
+        })
     }
     pub fn preview_failed<T>(file: &crate::files::File) -> HResult<T> {
         let name = file.name.clone();
-        Err(HError::PreviewFailed{ file: name })
-
+        Err(HError::PreviewFailed { file: name })
     }
 
     pub fn terminal_resized<T>() -> HResult<T> {
@@ -175,16 +188,13 @@ impl HError {
     pub fn input_updated<T>(input: String) -> HResult<T> {
         Err(HError::MiniBufferInputUpdated(input))
     }
-
-
 }
 
 #[derive(Fail, Debug, Clone)]
 pub enum ErrorCause {
     #[fail(display = "{}", _0)]
-    Str(String)
+    Str(String),
 }
-
 
 lazy_static! {
     static ref LOG: Mutex<Vec<LogEntry>> = Mutex::new(vec![]);
@@ -200,7 +210,10 @@ pub fn put_log<L: Into<LogEntry>>(log: L) -> HResult<()> {
     Ok(())
 }
 
-pub trait ErrorLog where Self: Sized {
+pub trait ErrorLog
+where
+    Self: Sized,
+{
     fn log(self);
     fn log_and(self) -> Self;
 }
@@ -220,7 +233,6 @@ pub trait ErrorLog where Self: Sized {
 //     }
 // }
 
-
 // impl<T> ErrorLog for Result<T, AError> {
 //     fn log(self) {
 //         if let Err(err) = self {
@@ -237,7 +249,9 @@ pub trait ErrorLog where Self: Sized {
 // }
 
 impl<T, E> ErrorLog for Result<T, E>
-where E: Into<HError> + Clone {
+where
+    E: Into<HError> + Clone,
+{
     fn log(self) {
         if let Err(err) = self {
             let err: HError = err.into();
@@ -254,11 +268,12 @@ where E: Into<HError> + Clone {
 }
 
 impl<E> ErrorLog for E
-where E: Into<HError> + Clone {
+where
+    E: Into<HError> + Clone,
+{
     fn log(self) {
         let err: HError = self.into();
         put_log(&err).ok();
-
     }
     fn log_and(self) -> Self {
         let err: HError = self.clone().into();
@@ -266,9 +281,6 @@ where E: Into<HError> + Clone {
         self
     }
 }
-
-
-
 
 impl From<std::io::Error> for HError {
     fn from(error: std::io::Error) -> Self {
@@ -326,16 +338,16 @@ impl<T> From<std::sync::TryLockError<T>> for HError {
     }
 }
 
-impl From<std::option::NoneError> for HError {
-    fn from(_error: std::option::NoneError) -> Self {
-        let err = HError::NoneError;
-        err
-    }
-}
+//impl From<std::option::NoneError> for HError {
+//fn from(_error: std::option::NoneError) -> Self {
+//let err = HError::NoneError;
+//err
+//}
+//}
 
 impl From<std::path::StripPrefixError> for HError {
     fn from(error: std::path::StripPrefixError) -> Self {
-        let err = HError::StripPrefixError{error: error };
+        let err = HError::StripPrefixError { error: error };
         err
     }
 }
@@ -361,7 +373,6 @@ impl From<std::str::Utf8Error> for HError {
     }
 }
 
-
 impl From<std::num::ParseIntError> for HError {
     fn from(error: std::num::ParseIntError) -> Self {
         let err = HError::ParseIntError(error);
@@ -383,7 +394,6 @@ impl From<std::char::ParseCharError> for HError {
     }
 }
 
-
 // MIME Errors
 
 #[derive(Fail, Debug, Clone)]
@@ -392,7 +402,7 @@ pub enum MimeError {
     NoFileProvided,
     #[fail(display = "File access failed! Error: {}", _0)]
     AccessFailed(Box<HError>),
-    #[fail(display = "No MIME type found for this file",)]
+    #[fail(display = "No MIME type found for this file")]
     NoMimeFound,
     #[fail(display = "Paniced while trying to find MIME type for: {}!", _0)]
     Panic(String),
@@ -403,7 +413,6 @@ impl From<MimeError> for HError {
         HError::Mime(e)
     }
 }
-
 
 impl From<KeyBindError> for HError {
     fn from(e: KeyBindError) -> Self {
@@ -416,7 +425,6 @@ impl From<crate::minibuffer::MiniBufferEvent> for HError {
         HError::MiniBufferEvent(e)
     }
 }
-
 
 #[derive(Fail, Debug, Clone)]
 pub enum KeyBindError {
@@ -433,8 +441,7 @@ pub enum KeyBindError {
     #[fail(display = "Couldn't parse as either char or u8: {}", _0)]
     CharOrNumParseError(String),
     #[fail(display = "Wanted {}, but got {}!", _0, _1)]
-    CharOrNumWrongType(String, String)
-
+    CharOrNumWrongType(String, String),
 }
 
 impl From<ini::ini::Error> for KeyBindError {

--- a/src/file_browser.rs
+++ b/src/file_browser.rs
@@ -1,33 +1,33 @@
-use termion::event::Key;
-use pathbuftools::PathBufTools;
-use osstrtools::OsStrTools;
 use async_value::Stale;
+use osstrtools::OsStrTools;
+use pathbuftools::PathBufTools;
+use termion::event::Key;
 
-use std::io::Write;
-use std::sync::{Arc, Mutex, RwLock};
-use std::path::PathBuf;
-use std::ffi::OsString;
-use std::os::unix::ffi::OsStringExt;
 use std::collections::HashSet;
+use std::ffi::OsString;
+use std::io::Write;
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, RwLock};
 
-use crate::files::{File, Files};
-use crate::fscache::FsCache;
-use crate::listview::{ListView, FileSource};
-use crate::hbox::HBox;
-use crate::widget::Widget;
-use crate::tabview::{TabView, Tabbable};
-use crate::preview::{Previewer, AsyncWidget};
-use crate::textview::TextView;
-use crate::fail::{HResult, HError, ErrorLog};
-use crate::widget::{Events, WidgetCore};
-use crate::proclist::ProcView;
 use crate::bookmarks::BMPopup;
-use crate::term;
-use crate::term::ScreenExt;
-use crate::foldview::LogView;
 use crate::coordinates::Coordinates;
 use crate::dirty::Dirtyable;
-use crate::stats::{FsStat, FsExt};
+use crate::fail::{ErrorLog, HError, HResult};
+use crate::files::{File, Files};
+use crate::foldview::LogView;
+use crate::fscache::FsCache;
+use crate::hbox::HBox;
+use crate::listview::{FileSource, ListView};
+use crate::preview::{AsyncWidget, Previewer};
+use crate::proclist::ProcView;
+use crate::stats::{FsExt, FsStat};
+use crate::tabview::{TabView, Tabbable};
+use crate::term;
+use crate::term::ScreenExt;
+use crate::textview::TextView;
+use crate::widget::Widget;
+use crate::widget::{Events, WidgetCore};
 
 #[derive(PartialEq)]
 pub enum FileBrowserWidgets {
@@ -77,7 +77,7 @@ impl Widget for FileBrowserWidgets {
         match self {
             FileBrowserWidgets::FileList(widget) => widget.on_key(key),
             FileBrowserWidgets::Previewer(widget) => widget.on_key(key),
-            FileBrowserWidgets::Blank(widget) => widget.on_key(key)
+            FileBrowserWidgets::Blank(widget) => widget.on_key(key),
         }
     }
 }
@@ -91,7 +91,7 @@ pub struct FileBrowser {
     bookmarks: Arc<Mutex<BMPopup>>,
     log_view: Arc<Mutex<LogView>>,
     fs_cache: FsCache,
-    fs_stat: Arc<RwLock<FsStat>>
+    fs_stat: Arc<RwLock<FsStat>>,
 }
 
 impl Tabbable for TabView<FileBrowser> {
@@ -108,10 +108,10 @@ impl Tabbable for TabView<FileBrowser> {
 
         let proc_view = cur_tab.proc_view.clone();
         let bookmarks = cur_tab.bookmarks.clone();
-        let log_view  = cur_tab.log_view.clone();
+        let log_view = cur_tab.log_view.clone();
         tab.proc_view = proc_view;
         tab.bookmarks = bookmarks;
-        tab.log_view  = log_view;
+        tab.log_view = log_view;
         tab.fs_stat = cur_tab.fs_stat.clone();
 
         self.push_widget(tab)?;
@@ -139,15 +139,18 @@ impl Tabbable for TabView<FileBrowser> {
     }
 
     fn get_tab_names(&self) -> Vec<Option<String>> {
-        self.widgets.iter().map(|filebrowser| {
-            let path = filebrowser.cwd.path();
-            let last_dir = path.components().last().unwrap();
-            let dir_name = last_dir.as_os_str().to_string_lossy().to_string();
-            Some(dir_name)
-        }).collect()
+        self.widgets
+            .iter()
+            .map(|filebrowser| {
+                let path = filebrowser.cwd.path();
+                let last_dir = path.components().last().unwrap();
+                let dir_name = last_dir.as_os_str().to_string_lossy().to_string();
+                Some(dir_name)
+            })
+            .collect()
     }
 
-    fn active_tab(& self) -> &Self::Tab {
+    fn active_tab(&self) -> &Self::Tab {
         self.active_tab_()
     }
 
@@ -163,35 +166,38 @@ impl Tabbable for TabView<FileBrowser> {
         match self.active_tab_mut().on_key(key) {
             // returned by specific tab when called with ExecCmd action
             Err(HError::FileBrowserNeedTabFiles) => {
-                let tab_dirs = self.widgets.iter().map(|w| w.cwd.clone())
+                let tab_dirs = self
+                    .widgets
+                    .iter()
+                    .map(|w| w.cwd.clone())
                     .collect::<Vec<_>>();
                 let selected_files = self
                     .widgets
                     .iter()
-                    .map(|w| {
-                        w.selected_files().unwrap_or(vec![])
-                    }).collect();
+                    .map(|w| w.selected_files().unwrap_or(vec![]))
+                    .collect();
 
                 self.widgets[self.active].exec_cmd(tab_dirs, selected_files)
             }
-            result @ _ => result
+            result @ _ => result,
         }
     }
 
     fn on_refresh(&mut self) -> HResult<()> {
-        let open_dirs = self.widgets
-            .iter()
-            .fold(HashSet::new(), |mut dirs, tab| {
-                tab.left_dir().map(|dir| dirs.insert(dir.clone())).ok();
-                dirs.insert(tab.cwd.clone());
-                tab.preview_widget()
-                    .map(|preview| preview.get_file().map(|file| {
+        let open_dirs = self.widgets.iter().fold(HashSet::new(), |mut dirs, tab| {
+            tab.left_dir().map(|dir| dirs.insert(dir.clone())).ok();
+            dirs.insert(tab.cwd.clone());
+            tab.preview_widget()
+                .map(|preview| {
+                    preview.get_file().map(|file| {
                         if file.is_dir() {
                             dirs.insert(file.clone());
                         }
-                    })).ok();
-                dirs
-            });
+                    })
+                })
+                .ok();
+            dirs
+        });
 
         self.active_tab_mut_().fs_cache.watch_only(open_dirs).log();
         self.active_tab_mut_().fs_stat.write()?.refresh().log();
@@ -202,33 +208,45 @@ impl Tabbable for TabView<FileBrowser> {
         let show_hidden = self.core.config().show_hidden();
 
         for tab in self.widgets.iter_mut() {
-            tab.left_async_widget_mut().map(|async_w| {
-                async_w.widget.on_ready(move |mut w, _| {
-                    w.as_mut()
-                     .map(|w| {
-                         if w.content.show_hidden != show_hidden {
-                             w.content.show_hidden = show_hidden;
-                             w.content.recalculate_len();
-                             w.refresh().log();
-                         }
-                     }).ok();
-                    Ok(())
-                }).log();
-            }).log();
+            tab.left_async_widget_mut()
+                .map(|async_w| {
+                    async_w
+                        .widget
+                        .on_ready(move |mut w, _| {
+                            w.as_mut()
+                                .map(|w| {
+                                    if w.content.show_hidden != show_hidden {
+                                        w.content.show_hidden = show_hidden;
+                                        w.content.recalculate_len();
+                                        w.refresh().log();
+                                    }
+                                })
+                                .ok();
+                            Ok(())
+                        })
+                        .log();
+                })
+                .log();
 
-            tab.main_async_widget_mut().map(|async_w| {
-                async_w.widget.on_ready(move |mut w, _| {
-                    w.as_mut()
-                     .map(|w| {
-                         if w.content.show_hidden != show_hidden {
-                             w.content.show_hidden = show_hidden;
-                             w.content.recalculate_len();
-                             w.refresh().log();
-                         }
-                     }).ok();
-                    Ok(())
-                }).log()
-            }).log();
+            tab.main_async_widget_mut()
+                .map(|async_w| {
+                    async_w
+                        .widget
+                        .on_ready(move |mut w, _| {
+                            w.as_mut()
+                                .map(|w| {
+                                    if w.content.show_hidden != show_hidden {
+                                        w.content.show_hidden = show_hidden;
+                                        w.content.recalculate_len();
+                                        w.refresh().log();
+                                    }
+                                })
+                                .ok();
+                            Ok(())
+                        })
+                        .log()
+                })
+                .log();
 
             tab.preview_widget_mut().map(|w| w.config_loaded()).ok();
             tab.columns.set_ratios(self.core.config().ratios);
@@ -236,13 +254,6 @@ impl Tabbable for TabView<FileBrowser> {
         Ok(())
     }
 }
-
-
-
-
-
-
-
 
 impl FileBrowser {
     pub fn new(core: &WidgetCore, cache: Option<FsCache>) -> HResult<FileBrowser> {
@@ -261,11 +272,12 @@ impl FileBrowser {
         core_m.coordinates = list_coords[1].clone();
         core_p.coordinates = list_coords[2].clone();
 
-        let main_path = cwd.ancestors()
-                           .take(1)
-                           .map(|path| {
-                               std::path::PathBuf::from(path)
-                           }).last()?;
+        let main_path = cwd
+            .ancestors()
+            .take(1)
+            .map(|path| std::path::PathBuf::from(path))
+            .last()
+            .ok_or_else(|| HError::NoneError)?;
         let left_path = main_path.parent().map(|p| p.to_path_buf());
 
         let cache = fs_cache.clone();
@@ -297,11 +309,14 @@ impl FileBrowser {
                 ListView::builder(core_l, source).build()
             });
 
-            left_widget.widget.on_ready(move |_, stale| {
-                // To stop from drawing empty placeholder
-                stale.set_stale()?;
-                Ok(())
-            }).log();
+            left_widget
+                .widget
+                .on_ready(move |_, stale| {
+                    // To stop from drawing empty placeholder
+                    stale.set_stale()?;
+                    Ok(())
+                })
+                .log();
 
             let left_widget = FileBrowserWidgets::FileList(left_widget);
             columns.push_widget(left_widget);
@@ -314,7 +329,6 @@ impl FileBrowser {
         columns.set_active(1).log();
         columns.refresh().log();
 
-
         let cwd = File::new_from_path(&cwd).unwrap();
 
         let proc_view = ProcView::new(&core);
@@ -322,17 +336,17 @@ impl FileBrowser {
         let log_view = LogView::new(&core, vec![]);
         let fs_stat = FsStat::new().unwrap();
 
-
-
-        Ok(FileBrowser { columns: columns,
-                         cwd: cwd,
-                         prev_cwd: None,
-                         core: core.clone(),
-                         proc_view: Arc::new(Mutex::new(proc_view)),
-                         bookmarks: Arc::new(Mutex::new(bookmarks)),
-                         log_view: Arc::new(Mutex::new(log_view)),
-                         fs_cache: fs_cache,
-                         fs_stat: Arc::new(RwLock::new(fs_stat)) })
+        Ok(FileBrowser {
+            columns: columns,
+            cwd: cwd,
+            prev_cwd: None,
+            core: core.clone(),
+            proc_view: Arc::new(Mutex::new(proc_view)),
+            bookmarks: Arc::new(Mutex::new(bookmarks)),
+            log_view: Arc::new(Mutex::new(log_view)),
+            fs_cache: fs_cache,
+            fs_stat: Arc::new(RwLock::new(fs_stat)),
+        })
     }
 
     pub fn enter_dir(&mut self) -> HResult<()> {
@@ -341,15 +355,16 @@ impl FileBrowser {
         if file.is_dir() {
             let dir = file;
             match dir.is_readable() {
-                Ok(true) => {},
+                Ok(true) => {}
                 Ok(false) => {
-                    let status =
-                        format!("{}Stop right there, cowboy! Check your permisions!",
-                                term::color_red());
+                    let status = format!(
+                        "{}Stop right there, cowboy! Check your permisions!",
+                        term::color_red()
+                    );
                     self.core.show_status(&status).log();
                     return Ok(());
                 }
-                err @ Err(_) => err.log()
+                err @ Err(_) => err.log(),
             }
             self.preview_widget_mut()?.set_stale().log();
             self.preview_widget_mut()?.cancel_animation().log();
@@ -360,36 +375,41 @@ impl FileBrowser {
             self.cwd = dir.clone();
 
             let cache = self.fs_cache.clone();
-            self.main_async_widget_mut()?.change_to(move |stale, core| {
-                let source = match previewer_files {
-                    Some(files) => FileSource::Files(files),
-                    None => FileSource::Path(dir)
-                };
+            self.main_async_widget_mut()?
+                .change_to(move |stale, core| {
+                    let source = match previewer_files {
+                        Some(files) => FileSource::Files(files),
+                        None => FileSource::Path(dir),
+                    };
 
-                ListView::builder(core, source)
-                    .with_cache(cache)
-                    .with_stale(stale.clone())
-                    .build()
-            }).log();
-
+                    ListView::builder(core, source)
+                        .with_cache(cache)
+                        .with_stale(stale.clone())
+                        .build()
+                })
+                .log();
 
             let cache = self.fs_cache.clone();
             let left_dir = self.cwd.parent_as_file()?;
-            self.left_async_widget_mut()?.change_to(move |stale, core| {
-                let source = match main_files {
-                    Some(files) => FileSource::Files(files),
-                    None => FileSource::Path(left_dir)
-                };
+            self.left_async_widget_mut()?
+                .change_to(move |stale, core| {
+                    let source = match main_files {
+                        Some(files) => FileSource::Files(files),
+                        None => FileSource::Path(left_dir),
+                    };
 
-                ListView::builder(core, source)
-                    .with_cache(cache)
-                    .with_stale(stale.clone())
-                    .build()
-                }).log();
+                    ListView::builder(core, source)
+                        .with_cache(cache)
+                        .with_stale(stale.clone())
+                        .build()
+                })
+                .log();
         } else {
-            self.preview_widget_mut().map(|preview| {
-                preview.cancel_animation().log();
-            }).log();
+            self.preview_widget_mut()
+                .map(|preview| {
+                    preview.cancel_animation().log();
+                })
+                .log();
             self.core.get_sender().send(Events::InputEnabled(false))?;
             self.core.screen.suspend().log();
 
@@ -403,12 +423,14 @@ impl FileBrowser {
             self.core.get_sender().send(Events::InputEnabled(true))?;
 
             match status {
-                Ok(status) =>
-                    self.core.show_status(&format!("\"{}\" exited with {}",
-                                                   "xdg-open", status)).log(),
-                Err(err) =>
-                    self.core.show_status(&format!("Can't run this \"{}\": {}",
-                                                   "xdg-open", err)).log()
+                Ok(status) => self
+                    .core
+                    .show_status(&format!("\"{}\" exited with {}", "xdg-open", status))
+                    .log(),
+                Err(err) => self
+                    .core
+                    .show_status(&format!("Can't run this \"{}\": {}", "xdg-open", err))
+                    .log(),
             }
         }
 
@@ -418,13 +440,15 @@ impl FileBrowser {
     pub fn move_down_left_widget(&mut self) -> HResult<()> {
         let left_files_pos = self.left_widget()?.get_selection();
 
-        let next_dir = self.get_left_files()?
+        let next_dir = self
+            .get_left_files()?
             .iter_files()
             .skip(left_files_pos + 1)
             .find(|&file| file.is_dir())
             .cloned();
 
-        self.main_widget_goto(&next_dir?).log();
+        self.main_widget_goto(&next_dir.ok_or_else(|| HError::NoneError)?)
+            .log();
 
         Ok(())
     }
@@ -432,7 +456,8 @@ impl FileBrowser {
     pub fn move_up_left_widget(&mut self) -> HResult<()> {
         let left_files_pos = self.left_widget()?.get_selection();
 
-        let next_dir = self.get_left_files()?
+        let next_dir = self
+            .get_left_files()?
             .iter_files()
             .take(left_files_pos)
             .collect::<Vec<&File>>()
@@ -441,7 +466,8 @@ impl FileBrowser {
             .find(|&file| file.is_dir())
             .cloned();
 
-        self.main_widget_goto(&next_dir?).log();
+        self.main_widget_goto(&next_dir.ok_or_else(|| HError::NoneError)?)
+            .log();
 
         Ok(())
     }
@@ -458,7 +484,7 @@ impl FileBrowser {
             cwd: cwd.clone(),
             cwd_files: None,
             tab_files: None,
-            tab_paths: None
+            tab_paths: None,
         };
 
         self.proc_view.lock()?.run_proc_raw(cmd)?;
@@ -466,7 +492,7 @@ impl FileBrowser {
         Ok(())
     }
 
-    pub fn main_widget_goto_wait(&mut self, dir :&File) -> HResult<()> {
+    pub fn main_widget_goto_wait(&mut self, dir: &File) -> HResult<()> {
         self.main_widget_goto(&dir)?;
 
         // replace this with on_ready_mut() later
@@ -480,9 +506,7 @@ impl FileBrowser {
     }
 
     pub fn main_widget_goto(&mut self, dir: &File) -> HResult<()> {
-        self.preview_widget_mut()
-            .map(|p| p.set_stale())
-            .ok();
+        self.preview_widget_mut().map(|p| p.set_stale()).ok();
 
         let dir = dir.clone();
         let cache = self.fs_cache.clone();
@@ -492,25 +516,24 @@ impl FileBrowser {
         let file_source = FileSource::Path(self.cwd.clone());
 
         let main_async_widget = self.main_async_widget_mut()?;
-        main_async_widget.change_to(move |stale: &Stale, core| {
-            let view = ListView::builder(core, file_source)
-                .with_cache(cache)
-                .with_stale(stale.clone())
-                .build()?;
+        main_async_widget
+            .change_to(move |stale: &Stale, core| {
+                let view = ListView::builder(core, file_source)
+                    .with_cache(cache)
+                    .with_stale(stale.clone())
+                    .build()?;
 
-            Ok(view)
-        }).log();
-
+                Ok(view)
+            })
+            .log();
 
         if let Ok(grand_parent) = self.cwd()?.parent_as_file() {
             self.left_widget_goto(&grand_parent).log();
         } else {
-            self.left_async_widget_mut()?.change_to(move |_,_| {
-                HError::stale()?
-            }).log();
+            self.left_async_widget_mut()?
+                .change_to(move |_, _| HError::stale()?)
+                .log();
         }
-
-
 
         Ok(())
     }
@@ -526,14 +549,16 @@ impl FileBrowser {
         let cache = self.fs_cache.clone();
         let file_source = FileSource::Path(dir.clone());
         let left_async_widget = self.left_async_widget_mut()?;
-        left_async_widget.change_to(move |stale, core| {
-            let view = ListView::builder(core, file_source)
-                .with_cache(cache)
-                .with_stale(stale.clone())
-                .build()?;
+        left_async_widget
+            .change_to(move |stale, core| {
+                let view = ListView::builder(core, file_source)
+                    .with_cache(cache)
+                    .with_stale(stale.clone())
+                    .build()?;
 
-            Ok(view)
-        }).log();
+                Ok(view)
+            })
+            .log();
 
         Ok(())
     }
@@ -552,47 +577,54 @@ impl FileBrowser {
             let files = self.take_left_files();
             let file_source = match files {
                 Ok(files) => FileSource::Files(files),
-                Err(_) => FileSource::Path(new_cwd.clone())
+                Err(_) => FileSource::Path(new_cwd.clone()),
             };
 
-            self.main_async_widget_mut()?.change_to(move |stale, core| {
-                ListView::builder(core, file_source)
-                    .select(main_selection)
-                    .with_cache(cache)
-                    .with_stale(stale.clone())
-                    .build()
-            }).log();
+            self.main_async_widget_mut()?
+                .change_to(move |stale, core| {
+                    ListView::builder(core, file_source)
+                        .select(main_selection)
+                        .with_cache(cache)
+                        .with_stale(stale.clone())
+                        .build()
+                })
+                .log();
 
             if let Ok(left_dir) = new_cwd.parent_as_file() {
                 let file_source = FileSource::Path(left_dir);
                 let cache = self.fs_cache.clone();
-                self.left_async_widget_mut()?.change_to(move |stale, core| {
-                    ListView::builder(core, file_source)
-                        .with_cache(cache)
-                        .with_stale(stale.clone())
-                        .build()
-                }).log();
+                self.left_async_widget_mut()?
+                    .change_to(move |stale, core| {
+                        ListView::builder(core, file_source)
+                            .with_cache(cache)
+                            .with_stale(stale.clone())
+                            .build()
+                    })
+                    .log();
             } else {
                 // Just place a dummy in the left column
-                self.left_async_widget_mut()?.change_to(move |_, core| {
-                    let files = Files::default();
-                    let source = FileSource::Files(files);
-                    ListView::builder(core, source).build()
-                }).log();
+                self.left_async_widget_mut()?
+                    .change_to(move |_, core| {
+                        let files = Files::default();
+                        let source = FileSource::Files(files);
+                        ListView::builder(core, source).build()
+                    })
+                    .log();
 
-                self.left_async_widget_mut()?.widget.on_ready(move |_, stale| {
-                    // To stop from drawing empty placeholder
-                    stale.set_stale()?;
-                    Ok(())
-                }).log()
+                self.left_async_widget_mut()?
+                    .widget
+                    .on_ready(move |_, stale| {
+                        // To stop from drawing empty placeholder
+                        stale.set_stale()?;
+                        Ok(())
+                    })
+                    .log()
             }
 
-
             if let Ok(preview_files) = preview_files {
-                self.preview_widget_mut().map(|preview| {
-                    preview.put_preview_files(preview_files,
-                                              previewer_selection)
-                }).ok();
+                self.preview_widget_mut()
+                    .map(|preview| preview.put_preview_files(preview_files, previewer_selection))
+                    .ok();
             }
         }
 
@@ -601,7 +633,7 @@ impl FileBrowser {
     }
 
     pub fn goto_prev_cwd(&mut self) -> HResult<()> {
-        let prev_cwd = self.prev_cwd.take()?;
+        let prev_cwd = self.prev_cwd.take().ok_or_else(|| HError::NoneError)?;
         self.main_widget_goto(&prev_cwd)?;
         Ok(())
     }
@@ -615,13 +647,19 @@ impl FileBrowser {
     fn get_boomark(&mut self) -> HResult<String> {
         let cwd = &match self.prev_cwd.as_ref() {
             Some(cwd) => cwd,
-            None => &self.cwd
-        }.path.to_string_lossy().to_string();
+            None => &self.cwd,
+        }
+        .path
+        .to_string_lossy()
+        .to_string();
 
-        self.bookmarks.lock()?.set_coordinates(&self.core.coordinates).log();
+        self.bookmarks
+            .lock()?
+            .set_coordinates(&self.core.coordinates)
+            .log();
 
         loop {
-            let bookmark =  self.bookmarks.lock()?.pick(cwd.to_string());
+            let bookmark = self.bookmarks.lock()?.pick(cwd.to_string());
 
             if let Err(HError::TerminalResizedError) = bookmark {
                 self.core.screen.clear().log();
@@ -673,22 +711,24 @@ impl FileBrowser {
     }
 
     pub fn update_preview(&mut self) -> HResult<()> {
-        if !self.main_async_widget_mut()?.ready() { return Ok(()) }
-        if self.main_widget()?
-            .content
-            .len() == 0 {
-                self.preview_widget_mut()?.set_stale().log();
-                return Ok(());
-            }
+        if !self.main_async_widget_mut()?.ready() {
+            return Ok(());
+        }
+        if self.main_widget()?.content.len() == 0 {
+            self.preview_widget_mut()?.set_stale().log();
+            return Ok(());
+        }
 
         let file = self.selected_file()?;
 
         // Don't even call previewer on empty files to save CPU cycles
         match (file.is_dir(), file.calculate_size()) {
-            (false, Ok((size, unit))) => if size == 0 && unit == "" {
-                self.preview_widget_mut()?.set_stale().log();
-                return Ok(());
-            },
+            (false, Ok((size, unit))) => {
+                if size == 0 && unit == "" {
+                    self.preview_widget_mut()?.set_stale().log();
+                    return Ok(());
+                }
+            }
             _ => {}
         }
 
@@ -698,13 +738,17 @@ impl FileBrowser {
     }
 
     pub fn set_left_selection(&mut self) -> HResult<()> {
-        if self.cwd.parent().is_none() { return Ok(()) }
-        if !self.left_async_widget_mut()?.ready() { return Ok(()) }
+        if self.cwd.parent().is_none() {
+            return Ok(());
+        }
+        if !self.left_async_widget_mut()?.ready() {
+            return Ok(());
+        }
 
         let selection = self.cwd()?.clone();
 
         // Saves doing iteration to find file's position
-        if let Some(ref current_selection) =  self.left_widget()?.current_item {
+        if let Some(ref current_selection) = self.left_widget()?.current_item {
             if current_selection.name == selection.name {
                 return Ok(());
             }
@@ -713,12 +757,13 @@ impl FileBrowser {
         self.left_widget_mut()?.select_file(&selection);
 
         let selected_file = self.left_widget()?.selected_file();
-        self.cwd.parent_as_file()
-                .map(|dir| {
-                    self.fs_cache
-                        .set_selection(dir.clone(), selected_file.clone())
-                }).log();
-
+        self.cwd
+            .parent_as_file()
+            .map(|dir| {
+                self.fs_cache
+                    .set_selection(dir.clone(), selected_file.clone())
+            })
+            .log();
 
         Ok(())
     }
@@ -747,12 +792,13 @@ impl FileBrowser {
 
     pub fn save_selected_file(&self) -> HResult<()> {
         self.selected_file()
-            .map(|f| self.fs_cache.set_selection(self.cwd.clone(),
-                                                 f))?
+            .map(|f| self.fs_cache.set_selection(self.cwd.clone(), f))?
     }
 
     pub fn save_tab_settings(&mut self) -> HResult<()> {
-        if !self.main_async_widget_mut()?.ready() { return Ok(()) }
+        if !self.main_async_widget_mut()?.ready() {
+            return Ok(());
+        }
 
         if self.main_widget()?.content.len() > 0 {
             let files = self.get_files()?;
@@ -762,7 +808,6 @@ impl FileBrowser {
 
         Ok(())
     }
-
 
     pub fn cwd(&self) -> HResult<&File> {
         Ok(&self.cwd)
@@ -788,77 +833,124 @@ impl FileBrowser {
 
     pub fn selected_files(&self) -> HResult<Vec<File>> {
         let widget = self.main_widget()?;
-        let files = widget.content.get_selected().into_iter().map(|f| {
-            f.clone()
-        }).collect();
+        let files = widget
+            .content
+            .get_selected()
+            .into_iter()
+            .map(|f| f.clone())
+            .collect();
         Ok(files)
     }
 
     pub fn main_async_widget_mut(&mut self) -> HResult<&mut AsyncWidget<ListView<Files>>> {
-        let widget = self.columns.active_widget_mut()?;
+        let widget = self
+            .columns
+            .active_widget_mut()
+            .ok_or_else(|| HError::NoneError)?;
 
         let widget = match widget {
             FileBrowserWidgets::FileList(filelist) => filelist,
-            _ => { HError::wrong_widget("previewer", "filelist")? }
+            _ => HError::wrong_widget("previewer", "filelist")?,
         };
         Ok(widget)
     }
 
     pub fn main_widget(&self) -> HResult<&ListView<Files>> {
-        let widget = self.columns.active_widget()?;
+        let widget = self
+            .columns
+            .active_widget()
+            .ok_or_else(|| HError::NoneError)?;
 
         let widget = match widget {
             FileBrowserWidgets::FileList(filelist) => filelist.widget(),
-            _ => { HError::wrong_widget("previewer", "filelist")? }
+            _ => HError::wrong_widget("previewer", "filelist")?,
         };
         widget
     }
 
     pub fn main_widget_mut(&mut self) -> HResult<&mut ListView<Files>> {
-        let widget = self.columns.active_widget_mut()?;
+        let widget = self
+            .columns
+            .active_widget_mut()
+            .ok_or_else(|| HError::NoneError)?;
 
         let widget = match widget {
             FileBrowserWidgets::FileList(filelist) => filelist.widget_mut(),
-            _ => { HError::wrong_widget("previewer", "filelist")? }
+            _ => HError::wrong_widget("previewer", "filelist")?,
         };
         widget
     }
 
     pub fn left_async_widget_mut(&mut self) -> HResult<&mut AsyncWidget<ListView<Files>>> {
-        let widget = match self.columns.widgets.get_mut(0)? {
+        let widget = match self
+            .columns
+            .widgets
+            .get_mut(0)
+            .ok_or_else(|| HError::NoneError)?
+        {
             FileBrowserWidgets::FileList(filelist) => filelist,
-            _ => { return HError::wrong_widget("previewer", "filelist"); }
+            _ => {
+                return HError::wrong_widget("previewer", "filelist");
+            }
         };
         Ok(widget)
     }
 
     pub fn left_widget(&self) -> HResult<&ListView<Files>> {
-        let widget = match self.columns.widgets.get(0)? {
+        let widget = match self
+            .columns
+            .widgets
+            .get(0)
+            .ok_or_else(|| HError::NoneError)?
+        {
             FileBrowserWidgets::FileList(filelist) => filelist.widget(),
-            _ => { return HError::wrong_widget("previewer", "filelist"); }
+            _ => {
+                return HError::wrong_widget("previewer", "filelist");
+            }
         };
         widget
     }
 
     pub fn left_widget_mut(&mut self) -> HResult<&mut ListView<Files>> {
-        let widget = match self.columns.widgets.get_mut(0)? {
+        let widget = match self
+            .columns
+            .widgets
+            .get_mut(0)
+            .ok_or_else(|| HError::NoneError)?
+        {
             FileBrowserWidgets::FileList(filelist) => filelist.widget_mut(),
-            _ => { return HError::wrong_widget("previewer", "filelist"); }
+            _ => {
+                return HError::wrong_widget("previewer", "filelist");
+            }
         };
         widget
     }
 
     pub fn preview_widget(&self) -> HResult<&Previewer> {
-        match self.columns.widgets.get(2)? {
+        match self
+            .columns
+            .widgets
+            .get(2)
+            .ok_or_else(|| HError::NoneError)?
+        {
             FileBrowserWidgets::Previewer(previewer) => Ok(previewer),
-            _ => { return HError::wrong_widget("filelist", "previewer"); }
+            _ => {
+                return HError::wrong_widget("filelist", "previewer");
+            }
         }
     }
 
     pub fn preview_widget_mut(&mut self) -> HResult<&mut Previewer> {
-        match self.columns.widgets.get_mut(2)? {
+        match self
+            .columns
+            .widgets
+            .get_mut(2)
+            .ok_or_else(|| HError::NoneError)?
+        {
             FileBrowserWidgets::Previewer(previewer) => Ok(previewer),
-            _ => { return HError::wrong_widget("filelist", "previewer"); }
+            _ => {
+                return HError::wrong_widget("filelist", "previewer");
+            }
         }
     }
 
@@ -870,24 +962,18 @@ impl FileBrowser {
 
     fn activate_main_widget(&mut self) {
         const MAIN_INDEX: usize = 1;
-        self.columns
-            .set_active(MAIN_INDEX)
-            .log();
+        self.columns.set_active(MAIN_INDEX).log();
     }
 
     fn activate_preview_widget(&mut self) {
         const PREVIEW_INDEX: usize = 2;
-        self.columns
-            .set_active(PREVIEW_INDEX)
-            .log();
+        self.columns.set_active(PREVIEW_INDEX).log();
     }
 
     pub fn toggle_colums(&mut self) {
         self.cancel_preview_animation();
         self.activate_main_widget();
-        self.columns
-            .toggle_zoom()
-            .log();
+        self.columns.toggle_zoom().log();
     }
 
     pub fn zoom_preview(&mut self) {
@@ -896,11 +982,10 @@ impl FileBrowser {
         self.preview_widget_mut()
             .map(|preview| {
                 preview.reload_text();
-            }).log();
-
-        self.columns
-            .toggle_zoom()
+            })
             .log();
+
+        self.columns.toggle_zoom().log();
     }
 
     pub fn quit_with_dir(&self) -> HResult<()> {
@@ -909,17 +994,20 @@ impl FileBrowser {
         let selected_file = selected_file.path.to_string_lossy();
         let selected_files = self.selected_files()?;
 
-        let selected_files = selected_files.iter().map(|f| {
-            format!("\"{}\" ", &f.path.to_string_lossy())
-        }).collect::<String>();
+        let selected_files = selected_files
+            .iter()
+            .map(|f| format!("\"{}\" ", &f.path.to_string_lossy()))
+            .collect::<String>();
 
-        let mut filepath = dirs_2::home_dir()?;
+        let mut filepath = dirs_2::home_dir().ok_or_else(|| HError::NoneError)?;
         filepath.push(".hunter_cwd");
 
-        let output = format!("HUNTER_CWD=\"{}\"\nF=\"{}\"\nMF=({})\n",
-                             cwd.to_str()?,
-                             selected_file,
-                             selected_files);
+        let output = format!(
+            "HUNTER_CWD=\"{}\"\nF=\"{}\"\nMF=({})\n",
+            cwd.to_str().ok_or_else(|| HError::NoneError)?,
+            selected_file,
+            selected_files
+        );
 
         let mut file = std::fs::File::create(filepath)?;
         file.write(output.as_bytes())?;
@@ -932,9 +1020,7 @@ impl FileBrowser {
         // Return and reset on cancel
         let orig_dir = self.cwd()?.clone();
         let orig_dir_selected_file = self.selected_file()?;
-        let mut orig_dir_filter = self.main_widget()?
-                                      .content
-                                      .get_filter();
+        let mut orig_dir_filter = self.main_widget()?.content.get_filter();
 
         // For current dir
         let mut selected_file = Some(orig_dir_selected_file.clone());
@@ -944,10 +1030,11 @@ impl FileBrowser {
         let dir_restore =
             |s: &mut FileBrowser, filter: Option<Option<String>>, file: Option<File>| {
                 s.main_widget_mut()
-                 .map(|mw| {
-                     filter.map(|f| mw.set_filter(f));
-                     file.map(|f| mw.select_file(&f));
-                 }).log();
+                    .map(|mw| {
+                        filter.map(|f| mw.set_filter(f));
+                        file.map(|f| mw.select_file(&f));
+                    })
+                    .log();
             };
 
         loop {
@@ -980,9 +1067,7 @@ impl FileBrowser {
                             if input.ends_with('/') {
                                 match input.as_str() {
                                     "../" => {
-                                        dir_restore(self,
-                                                    filter.take(),
-                                                    selected_file.take());
+                                        dir_restore(self, filter.take(), selected_file.take());
                                         self.go_back().log();
                                         self.core.minibuffer_clear().log();
                                     }
@@ -990,9 +1075,7 @@ impl FileBrowser {
                                         let sel = self.selected_file()?;
 
                                         if sel.is_dir() {
-                                            dir_restore(self,
-                                                        filter.take(),
-                                                        selected_file.take());
+                                            dir_restore(self, filter.take(), selected_file.take());
                                             self.main_widget_goto(&sel)?;
                                             self.core.minibuffer_clear().log();
                                         }
@@ -1004,9 +1087,7 @@ impl FileBrowser {
                             // Save current filter, if existing, before overwriting it
                             // Type is Option<Option<_>>, because filter itself is Option<_>
                             if filter.is_none() {
-                                let dir_filter = self.main_widget()?
-                                                     .content
-                                                     .get_filter();
+                                let dir_filter = self.main_widget()?.content.get_filter();
                                 filter = Some(dir_filter);
                             }
 
@@ -1015,8 +1096,7 @@ impl FileBrowser {
                                 selected_file = Some(self.selected_file()?);
                             }
 
-                            self.main_widget_mut()?
-                                .set_filter(Some(input));
+                            self.main_widget_mut()?.set_filter(Some(input));
                         }
                         // Restore original directory and filter/selection
                         Cancelled => {
@@ -1024,7 +1104,7 @@ impl FileBrowser {
                             // Special case, because all others fail if directory isn't ready anyway
                             self.main_async_widget_mut()?
                                 .widget
-                                .on_ready(move |mw,_| {
+                                .on_ready(move |mw, _| {
                                     let mw = mw?;
                                     mw.set_filter(orig_dir_filter.take());
                                     mw.select_file(&orig_dir_selected_file);
@@ -1063,8 +1143,8 @@ impl FileBrowser {
                             selected_file = Some(self.selected_file()?);
                         }
                     }
-                },
-                _ => {  }
+                }
+                _ => {}
             }
         }
 
@@ -1073,15 +1153,13 @@ impl FileBrowser {
 
     fn external_select(&mut self) -> HResult<()> {
         let shell = std::env::var("SHELL").unwrap_or("bash".into());
-        let cmd = self.core
-            .config.read()?
-            .get()?
-            .select_cmd
-            .clone();
+        let cmd = self.core.config.read()?.get()?.select_cmd.clone();
 
         self.core.get_sender().send(Events::InputEnabled(false))?;
         self.core.screen.suspend().log();
-        self.preview_widget().map(|preview| preview.cancel_animation()).log();
+        self.preview_widget()
+            .map(|preview| preview.cancel_animation())
+            .log();
 
         let cmd_result = std::process::Command::new(shell)
             .arg("-c")
@@ -1126,29 +1204,25 @@ impl FileBrowser {
 
                                 self.main_widget_goto(&dir).log();
 
-                                self.main_async_widget_mut()?
-                                    .widget
-                                    .on_ready(move |w, _| {
-                                        w?.select_file(&file);
-                                        Ok(())
-                                    })?;
+                                self.main_async_widget_mut()?.widget.on_ready(move |w, _| {
+                                    w?.select_file(&file);
+                                    Ok(())
+                                })?;
                             }
                         } else {
-                            let msg = format!("Can't access path: {}!",
-                                              path.to_string_lossy());
+                            let msg = format!("Can't access path: {}!", path.to_string_lossy());
                             self.core.show_status(&msg).log();
                         }
                     } else {
                         let mut last_file = None;
                         for file_path in paths {
                             if !file_path.exists() {
-                                let msg = format!("Can't find: {}",
-                                                  file_path .to_string_lossy());
+                                let msg = format!("Can't find: {}", file_path.to_string_lossy());
                                 self.core.show_status(&msg).log();
                                 continue;
                             }
 
-                            let dir_path = file_path.parent()?;
+                            let dir_path = file_path.parent().ok_or_else(|| HError::NoneError)?;
                             if self.cwd.path != dir_path {
                                 let file_dir = File::new_from_path(&dir_path);
 
@@ -1164,16 +1238,18 @@ impl FileBrowser {
                                 });
                         }
 
-                        self.main_widget_mut().map(|w| {
-                            last_file.map(|f| w.select_file(&f));
-                            w.content.set_dirty();
-                        }).log();
+                        self.main_widget_mut()
+                            .map(|w| {
+                                last_file.map(|f| w.select_file(&f));
+                                w.content.set_dirty();
+                            })
+                            .log();
                     }
                 } else {
                     self.core.show_status("External program failed!").log();
                 }
             }
-            Err(_) => self.core.show_status("Can't run external program!").log()
+            Err(_) => self.core.show_status("Can't run external program!").log(),
         }
 
         Ok(())
@@ -1181,15 +1257,13 @@ impl FileBrowser {
 
     fn external_cd(&mut self) -> HResult<()> {
         let shell = std::env::var("SHELL").unwrap_or("bash".into());
-        let cmd = self.core
-            .config.read()?
-            .get()?
-            .cd_cmd
-            .clone();
+        let cmd = self.core.config.read()?.get()?.cd_cmd.clone();
 
         self.core.get_sender().send(Events::InputEnabled(false))?;
         self.core.screen.suspend().log();
-        self.preview_widget().map(|preview| preview.cancel_animation()).log();
+        self.preview_widget()
+            .map(|preview| preview.cancel_animation())
+            .log();
 
         let cmd_result = std::process::Command::new(shell)
             .arg("-c")
@@ -1221,28 +1295,22 @@ impl FileBrowser {
                         if path.is_dir() {
                             let dir = File::new_from_path(&path)?;
                             self.main_widget_goto(&dir).log();
-                        }
-                        else {
-                            let msg = format!("Can't access path: {}!",
-                                              path.to_string_lossy());
+                        } else {
+                            let msg = format!("Can't access path: {}!", path.to_string_lossy());
                             self.core.show_status(&msg).log();
                         }
-
                     } else {
                         self.core.show_status("External program failed!").log();
                     }
                 }
             }
-            Err(_) => self.core.show_status("Can't run external program!").log()
+            Err(_) => self.core.show_status("Can't run external program!").log(),
         }
 
         Ok(())
     }
 
-
-    fn exec_cmd(&mut self,
-                tab_dirs: Vec<File>,
-                tab_files: Vec<Vec<File>>) -> HResult<()> {
+    fn exec_cmd(&mut self, tab_dirs: Vec<File>, tab_files: Vec<Vec<File>>) -> HResult<()> {
         let cwd = self.cwd()?.clone();
         let selected_file = self.selected_file().ok();
         let selected_files = self.selected_files().ok();
@@ -1269,7 +1337,7 @@ impl FileBrowser {
             cwd: cwd,
             cwd_files: cwd_files,
             tab_files: Some(tab_files),
-            tab_paths: Some(tab_dirs)
+            tab_paths: Some(tab_dirs),
         };
 
         self.proc_view.lock()?.run_proc_subshell(cmd)?;
@@ -1280,7 +1348,9 @@ impl FileBrowser {
     pub fn run_subshell(&mut self) -> HResult<()> {
         self.core.get_sender().send(Events::InputEnabled(false))?;
 
-        self.preview_widget().map(|preview| preview.cancel_animation()).log();
+        self.preview_widget()
+            .map(|preview| preview.cancel_animation())
+            .log();
         self.core.screen.suspend().log();
 
         let shell = std::env::var("SHELL").unwrap_or("bash".into());
@@ -1288,45 +1358,49 @@ impl FileBrowser {
 
         self.core.screen.activate().log();
 
-
         self.core.get_sender().send(Events::InputEnabled(true))?;
 
         match status {
-            Ok(status) =>
-                self.core.show_status(&format!("\"{}\" exited with {}",
-                                          shell, status)).log(),
-            Err(err) =>
-                self.core.show_status(&format!("Can't run this \"{}\": {}",
-                                          shell, err)).log()
+            Ok(status) => self
+                .core
+                .show_status(&format!("\"{}\" exited with {}", shell, status))
+                .log(),
+            Err(err) => self
+                .core
+                .show_status(&format!("Can't run this \"{}\": {}", shell, err))
+                .log(),
         }
-
-
 
         Ok(())
     }
 
     pub fn show_procview(&mut self) -> HResult<()> {
-        self.preview_widget().map(|preview| preview.cancel_animation()).log();
+        self.preview_widget()
+            .map(|preview| preview.cancel_animation())
+            .log();
         let procview = self.proc_view.clone();
         loop {
             match procview.lock()?.popup() {
                 // Ignore refresh
                 Err(HError::RefreshParent) => continue,
-                Err(HError::TerminalResizedError) |
-                Err(HError::WidgetResizedError) => self.resize().log(),
-                _ => break
+                Err(HError::TerminalResizedError) | Err(HError::WidgetResizedError) => {
+                    self.resize().log()
+                }
+                _ => break,
             }
         }
         Ok(())
     }
 
     pub fn show_log(&mut self) -> HResult<()> {
-        self.preview_widget().map(|preview| preview.cancel_animation()).log();
+        self.preview_widget()
+            .map(|preview| preview.cancel_animation())
+            .log();
         loop {
             let res = self.log_view.lock()?.popup();
 
             if let Err(HError::RefreshParent) = res {
-                continue
+                continue;
             }
 
             if let Err(HError::TerminalResizedError) = res {
@@ -1334,7 +1408,7 @@ impl FileBrowser {
                 continue;
             }
 
-            break
+            break;
         }
 
         Ok(())
@@ -1342,17 +1416,17 @@ impl FileBrowser {
 
     pub fn quick_action(&self) -> HResult<()> {
         let files = self.selected_files()?;
-        let files = if files.len() > 0 { files }
-        else { vec![self.selected_file()?.clone()] };
+        let files = if files.len() > 0 {
+            files
+        } else {
+            vec![self.selected_file()?.clone()]
+        };
 
         let sender = self.core.get_sender();
         let core = self.preview_widget()?.get_core()?.clone();
         let proc_view = self.proc_view.clone();
 
-        crate::quick_actions::open(files,
-                                   sender,
-                                   core,
-                                   proc_view)?;
+        crate::quick_actions::open(files, sender, core, proc_view)?;
         Ok(())
     }
 
@@ -1361,24 +1435,27 @@ impl FileBrowser {
         let ypos = self.get_coordinates()?.position().y();
         let file = self.selected_file()?;
 
-
         let permissions = file.pretty_print_permissions().unwrap_or("NOPERMS".into());
         let user = file.pretty_user().unwrap_or("NOUSER".into());
         let group = file.pretty_group().unwrap_or("NOGROUP".into());
         let mtime = file.pretty_mtime().unwrap_or("NOMTIME".into());
         let target = if let Some(target) = &file.target {
             "--> ".to_string() + &target.short_string()
-        } else { "".to_string() };
+        } else {
+            "".to_string()
+        };
 
         let main_widget = self.main_widget()?;
         let selection = main_widget.get_selection() + 1;
         let file_count = main_widget.content.len();
         let file_count = format!("{}", file_count);
         let digits = file_count.len();
-        let file_count = format!("{:digits$}/{:digits$}",
-                                 selection,
-                                 file_count,
-                                 digits = digits);
+        let file_count = format!(
+            "{:digits$}/{:digits$}",
+            selection,
+            file_count,
+            digits = digits
+        );
         let count_xpos = xsize - file_count.len() as u16;
         let count_ypos = ypos + self.get_coordinates()?.ysize();
 
@@ -1387,32 +1464,32 @@ impl FileBrowser {
         let dev = fs.get_dev().unwrap_or(String::from(""));
         let free_space = fs.get_free();
         let total_space = fs.get_total();
-        let space = format!("{}{} / {}",
-                            dev,
-                            free_space,
-                            total_space);
+        let space = format!("{}{} / {}", dev, free_space, total_space);
 
         let space_xpos = count_xpos - space.len() as u16 - 5; // - 3;
 
-        let status = format!("{} {}:{} {}{} {}{}",
-                             permissions,
-                             user,
-                             group,
-                             crate::term::header_color(),
-                             mtime,
-                             crate::term::color_yellow(),
-                             target
+        let status = format!(
+            "{} {}:{} {}{} {}{}",
+            permissions,
+            user,
+            group,
+            crate::term::header_color(),
+            mtime,
+            crate::term::color_yellow(),
+            target
         );
-        let status = crate::term::sized_string_u(&status, (xsize-1) as usize);
+        let status = crate::term::sized_string_u(&status, (xsize - 1) as usize);
 
-        let status = format!("{}{}{}{}{}{} | {}",
-                             status,
-                             crate::term::header_color(),
-                             crate::term::goto_xy(space_xpos, count_ypos),
-                             crate::term::color_orange(),
-                             space,
-                             crate::term::header_color(),
-                             file_count);
+        let status = format!(
+            "{}{}{}{}{}{} | {}",
+            status,
+            crate::term::header_color(),
+            crate::term::goto_xy(space_xpos, count_ypos),
+            crate::term::color_orange(),
+            space,
+            crate::term::header_color(),
+            file_count
+        );
 
         Ok(status)
     }
@@ -1443,42 +1520,42 @@ impl Widget for FileBrowser {
         let fcolor = file.get_color();
 
         let color = if file.is_dir() {
-            crate::term::highlight_color() }
-        else {
+            crate::term::highlight_color()
+        } else {
             match fcolor {
                 Some(color) => color,
-                None => crate::term::normal_color()
+                None => crate::term::normal_color(),
             }
         };
 
         let path = self.cwd.short_string();
 
         let mut path = path;
-        if &path == "" { path.clear(); }
-        if &path == "~/" { path.pop(); }
-        if &path == "/" { path.pop(); }
+        if &path == "" {
+            path.clear();
+        }
+        if &path == "~/" {
+            path.pop();
+        }
+        if &path == "/" {
+            path.pop();
+        }
 
-
-        let pretty_path = format!("{}/{}{}", path, &color, name );
+        let pretty_path = format!("{}/{}{}", path, &color, name);
         let sized_path = crate::term::sized_string(&pretty_path, xsize);
         Ok(sized_path.to_string())
     }
 
     fn render_footer(&self) -> HResult<String> {
         let xsize = term::xsize_u();
-        let mut status = self.get_core()?
-                             .status_bar_content
-                             .lock()?;
-        let status = status.as_mut()
-                           .take();
-        let active = self.columns
-                         .active
-                         .unwrap_or(1);
+        let mut status = self.get_core()?.status_bar_content.lock()?;
+        let status = status.as_mut().take();
+        let active = self.columns.active.unwrap_or(1);
 
         match (status, active) {
             (Some(status), _) => Ok(term::sized_string_u(&status, xsize)),
-            (_,            2) => self.preview_widget()?.render_footer(),
-            _                 => self.get_footer(),
+            (_, 2) => self.preview_widget()?.render_footer(),
+            _ => self.get_footer(),
         }
     }
 
@@ -1487,7 +1564,9 @@ impl Widget for FileBrowser {
         self.columns.refresh().log();
         self.set_left_selection().log();
         self.set_cwd().log();
-        if !self.columns.zoom_active { self.update_preview().log(); }
+        if !self.columns.zoom_active {
+            self.update_preview().log();
+        }
         self.columns.refresh().log();
         Ok(())
     }
@@ -1511,28 +1590,33 @@ impl Widget for FileBrowser {
                 return Ok(());
             }
             (_, Some(2)) => {
-                self.columns.active_widget_mut()?.on_key(key)?;
+                self.columns
+                    .active_widget_mut()
+                    .ok_or_else(|| HError::NoneError)?
+                    .on_key(key)?;
                 return Ok(());
             }
             _ => {}
         }
 
         match self.do_key(key) {
-            Err(HError::WidgetUndefinedKeyError{..}) => {
+            Err(HError::WidgetUndefinedKeyError { .. }) => {
                 match self.main_widget_mut()?.on_key(key) {
                     Ok(_) => {
                         self.save_tab_settings()?;
                     }
-                    Err(HError::WidgetUndefinedKeyError{..}) => {
+                    Err(HError::WidgetUndefinedKeyError { .. }) => {
                         self.preview_widget_mut()?.on_key(key)?
                     }
-                    e @ _ => e?
+                    e @ _ => e?,
                 }
             }
-            e @ _ => e?
+            e @ _ => e?,
         };
 
-        if !self.columns.zoom_active { self.update_preview().log(); }
+        if !self.columns.zoom_active {
+            self.update_preview().log();
+        }
         Ok(())
     }
 }
@@ -1540,7 +1624,7 @@ impl Widget for FileBrowser {
 use crate::keybind::{Acting, Bindings, FileBrowserAction, Movement};
 
 impl Acting for FileBrowser {
-    type Action=FileBrowserAction;
+    type Action = FileBrowserAction;
 
     fn search_in(&self) -> Bindings<Self::Action> {
         self.core.config().keybinds.filebrowser
@@ -1587,7 +1671,7 @@ impl Acting for FileBrowser {
             ToggleColumns => self.toggle_colums(),
             ZoomPreview => self.zoom_preview(),
             // Tab implementation needs to call exec_cmd because ALL files are needed
-            ExecCmd => Err(HError::FileBrowserNeedTabFiles)?
+            ExecCmd => Err(HError::FileBrowserNeedTabFiles)?,
         }
         Ok(())
     }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,42 +1,37 @@
 use std::cmp::Ord;
 use std::collections::{HashMap, HashSet};
-use std::ops::Index;
+use std::ffi::OsStr;
 use std::fs::Metadata;
+use std::hash::{Hash, Hasher};
+use std::ops::Index;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
-use std::sync::mpsc::Sender;
-use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::ffi::OsStr;
+use std::sync::mpsc::Sender;
+use std::sync::{Arc, RwLock};
 
+use chrono::TimeZone;
 use failure;
+use failure::Error;
 use failure::Fail;
 use lscolors::LsColors;
-use tree_magic_fork;
-use users::{get_current_username,
-            get_current_groupname,
-            get_user_by_uid,
-            get_group_by_gid};
-use chrono::TimeZone;
-use failure::Error;
-use rayon::{ThreadPool, ThreadPoolBuilder};
-use natord::compare;
 use mime_guess;
+use natord::compare;
+use nix::{dir::*, fcntl::OFlag, sys::stat::Mode};
 use rayon::prelude::*;
-use nix::{dir::*,
-          fcntl::OFlag,
-          sys::stat::Mode};
+use rayon::{ThreadPool, ThreadPoolBuilder};
+use tree_magic_fork;
+use users::{get_current_groupname, get_current_username, get_group_by_gid, get_user_by_uid};
 
-use pathbuftools::PathBufTools;
 use async_value::{Async, Stale, StopIter};
+use pathbuftools::PathBufTools;
 
-use crate::fail::{HResult, HError, ErrorLog};
 use crate::dirty::{DirtyBit, Dirtyable};
-use crate::widget::Events;
-use crate::icon::Icons;
+use crate::fail::{ErrorLog, HError, HResult};
 use crate::fscache::{FsCache, FsEvent};
+use crate::icon::Icons;
+use crate::widget::Events;
 
 lazy_static! {
     static ref COLORS: LsColors = LsColors::from_env().unwrap_or_default();
@@ -52,7 +47,7 @@ pub fn tick_str() -> &'static str {
         0 => "   ",
         1 => ".  ",
         2 => ".. ",
-        _ => "..."
+        _ => "...",
     }
 }
 
@@ -60,7 +55,7 @@ pub fn start_ticking(sender: Sender<Events>) {
     use std::time::Duration;
 
     IOTICK_CLIENTS.fetch_add(1, Ordering::Relaxed);
-    if IOTICK_CLIENTS.load(Ordering::Relaxed) == 1 {
+    if IOTICK_CLIENTS.load(Ordering::Acquire) == 1 {
         std::thread::spawn(move || {
             IOTICK.store(0, Ordering::Relaxed);
 
@@ -72,11 +67,10 @@ pub fn start_ticking(sender: Sender<Events>) {
                 IOTICK.fetch_add(1, Ordering::Relaxed);
 
                 // Send refresh event before sleeping
-                sender.send(crate::widget::Events::WidgetReady)
-                      .unwrap();
+                sender.send(crate::widget::Events::WidgetReady).unwrap();
 
                 // All jobs done?
-                if IOTICK_CLIENTS.load(Ordering::Relaxed) == 0 {
+                if IOTICK_CLIENTS.load(Ordering::Acquire) == 0 {
                     IOTICK.store(0, Ordering::Relaxed);
                     return;
                 }
@@ -128,9 +122,7 @@ pub fn load_tags() -> HResult<()> {
         }
 
         let tags = std::fs::read_to_string(tag_path)?;
-        let mut tags = tags.lines()
-                           .map(PathBuf::from)
-                           .collect::<Vec<PathBuf>>();
+        let mut tags = tags.lines().map(PathBuf::from).collect::<Vec<PathBuf>>();
         tags.sort();
         let mut tag_lock = TAGS.write()?;
         tag_lock.0 = true;
@@ -153,16 +145,21 @@ pub fn import_tags() -> HResult<()> {
 
 pub fn check_tag(path: &PathBuf) -> HResult<bool> {
     tags_loaded()?;
-    let tagged = TAGS.read()?.1.binary_search(path)
-                               .map_or_else(|_| false,
-                                            |_| true);
+    let tagged = TAGS
+        .read()?
+        .1
+        .binary_search(path)
+        .map_or_else(|_| false, |_| true);
     Ok(tagged)
 }
 
 pub fn tags_loaded() -> HResult<()> {
     let loaded = TAGS.read()?.0;
-    if loaded { Ok(()) }
-    else { HError::tags_not_loaded() }
+    if loaded {
+        Ok(())
+    } else {
+        HError::tags_not_loaded()
+    }
 }
 
 #[derive(Derivative)]
@@ -170,14 +167,11 @@ pub fn tags_loaded() -> HResult<()> {
 pub struct RefreshPackage {
     pub new_files: Option<Vec<File>>,
     pub new_len: usize,
-    #[derivative(Debug="ignore")]
-    #[derivative(PartialEq="ignore")]
-    #[derivative(Hash="ignore")]
-    pub jobs: Vec<Job>
+    #[derivative(Debug = "ignore")]
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
+    pub jobs: Vec<Job>,
 }
-
-
-
 
 impl RefreshPackage {
     fn new(mut files: Files, events: Vec<FsEvent>) -> RefreshPackage {
@@ -219,7 +213,6 @@ impl RefreshPackage {
         // Drop would set this stale after the function returns
         let stale = files.stale.take().unwrap();
 
-
         for event in events.into_iter().stop_stale(stale.clone()) {
             match event {
                 Create(mut file) => {
@@ -239,7 +232,7 @@ impl RefreshPackage {
                         files.files[fpos].rename(&new.path).log();
                         let job = files.files[fpos].refresh_meta_job();
                         jobs.push(job);
-                            }
+                    }
                 }
                 Remove(file) => {
                     if let Some(_) = file_pos_map.get(&file) {
@@ -254,8 +247,8 @@ impl RefreshPackage {
             return RefreshPackage {
                 new_files: None,
                 new_len: 0,
-                jobs: jobs
-            }
+                jobs: jobs,
+            };
         }
 
         if deleted_files.len() > 0 {
@@ -270,9 +263,9 @@ impl RefreshPackage {
         files.sort();
 
         // Need to unpack this to prevent issue with recursive Files type
-            // Also, if no files remain add placeholder and set len
+        // Also, if no files remain add placeholder and set len
         let (files, new_len) = if files.len() > 0 {
-                (std::mem::take(&mut files.files), files.len)
+            (std::mem::take(&mut files.files), files.len)
         } else {
             let placeholder = File::new_placeholder(&files.directory.path).unwrap();
             files.files.push(placeholder);
@@ -282,15 +275,17 @@ impl RefreshPackage {
         RefreshPackage {
             new_files: Some(files),
             new_len: new_len,
-            jobs: jobs
+            jobs: jobs,
         }
     }
 }
 
 // Tuple that stores path and "slots" to store metaadata in
-pub type Job = (PathBuf,
-                Option<Arc<RwLock<Option<Metadata>>>>,
-                Option<Arc<(AtomicBool, AtomicUsize)>>);
+pub type Job = (
+    PathBuf,
+    Option<Arc<RwLock<Option<Metadata>>>>,
+    Option<Arc<(AtomicBool, AtomicUsize)>>,
+);
 
 #[derive(Derivative)]
 #[derivative(PartialEq, Eq, Hash, Clone, Debug)]
@@ -298,13 +293,13 @@ pub struct Files {
     pub directory: File,
     pub files: Vec<File>,
     pub len: usize,
-    #[derivative(Debug="ignore")]
-    #[derivative(PartialEq="ignore")]
-    #[derivative(Hash="ignore")]
+    #[derivative(Debug = "ignore")]
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     pub pending_events: Arc<RwLock<Vec<FsEvent>>>,
-    #[derivative(Debug="ignore")]
-    #[derivative(PartialEq="ignore")]
-    #[derivative(Hash="ignore")]
+    #[derivative(Debug = "ignore")]
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     pub refresh: Option<Async<RefreshPackage>>,
     pub meta_upto: Option<usize>,
     pub sort: SortBy,
@@ -314,18 +309,18 @@ pub struct Files {
     pub filter: Option<String>,
     pub filter_selected: bool,
     pub dirty: DirtyBit,
-    #[derivative(Debug="ignore")]
-    #[derivative(PartialEq="ignore")]
-    #[derivative(Hash="ignore")]
+    #[derivative(Debug = "ignore")]
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     pub jobs: Vec<Job>,
-    #[derivative(Debug="ignore")]
-    #[derivative(PartialEq="ignore")]
-    #[derivative(Hash="ignore")]
+    #[derivative(Debug = "ignore")]
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
     pub cache: Option<FsCache>,
-    #[derivative(Debug="ignore")]
-    #[derivative(PartialEq="ignore")]
-    #[derivative(Hash="ignore")]
-    pub stale: Option<Stale>
+    #[derivative(Debug = "ignore")]
+    #[derivative(PartialEq = "ignore")]
+    #[derivative(Hash = "ignore")]
+    pub stale: Option<Stale>,
 }
 
 impl Index<usize> for Files {
@@ -334,7 +329,6 @@ impl Index<usize> for Files {
         &self.files[pos]
     }
 }
-
 
 impl Dirtyable for Files {
     fn is_dirty(&self) -> bool {
@@ -370,7 +364,7 @@ impl Default for Files {
             dirty: DirtyBit::new(),
             jobs: vec![],
             cache: None,
-            stale: None
+            stale: None,
         }
     }
 }
@@ -378,12 +372,9 @@ impl Default for Files {
 // Stop processing stuff when Files is dropped
 impl Drop for Files {
     fn drop(&mut self) {
-        self.stale
-            .as_ref()
-            .map(|s| s.set_stale());
+        self.stale.as_ref().map(|s| s.set_stale());
     }
 }
-
 
 #[cfg(target_os = "linux")]
 #[repr(C)]
@@ -395,7 +386,6 @@ pub struct linux_dirent {
     pub d_type: u8,
     pub d_name: [u8; 0],
 }
-
 
 // This arcane spell hastens the target by around 30%.
 
@@ -415,8 +405,11 @@ pub struct linux_dirent {
 // report the kind of file in d_type. Currently that means calling
 // stat on ALL files and ithrowing away the result. This is wasteful.
 #[cfg(target_os = "linux")]
-pub fn from_getdents(fd: i32, path: &Path, nothidden: &AtomicUsize)  -> Result<Vec<File>, FileError>
-{
+pub fn from_getdents(
+    fd: i32,
+    path: &Path,
+    nothidden: &AtomicUsize,
+) -> Result<Vec<File>, FileError> {
     use libc::SYS_getdents64;
 
     // Buffer size was chosen after measuring different sizes and 4k seemed best
@@ -435,9 +428,8 @@ pub fn from_getdents(fd: i32, path: &Path, nothidden: &AtomicUsize)  -> Result<V
         More(Vec<File>),
         Skip,
         Done,
-        Err(FileError)
+        Err(FileError),
     }
-
 
     let result = crossbeam::scope(|s| {
         loop {
@@ -449,8 +441,7 @@ pub fn from_getdents(fd: i32, path: &Path, nothidden: &AtomicUsize)  -> Result<V
                 break;
             } else if nread < 0 {
                 let pathstr = path.to_string_lossy().to_string();
-                HError::log::<()>(&format!("Couldn't read dents from: {}",
-                                           &pathstr)).ok();
+                HError::log::<()>(&format!("Couldn't read dents from: {}", &pathstr)).ok();
                 break;
             }
 
@@ -475,22 +466,26 @@ pub fn from_getdents(fd: i32, path: &Path, nothidden: &AtomicUsize)  -> Result<V
                     // long as the kernel doesn't provide wrong values and
                     // the calculations are corrent this is safe to do.
                     // It's bascally (buffer[n] -> buffer[n + len(buffer[n])
-                    let d: &linux_dirent = unsafe {
-                        std::mem::transmute::<usize, &linux_dirent>(bufptr  + bpos )
-                    };
+                    let d: &linux_dirent =
+                        unsafe { std::mem::transmute::<usize, &linux_dirent>(bufptr + bpos) };
 
                     // Name lenegth is overallocated, true length can be found by checking with strlen
-                    let name_len = d.d_reclen as usize -
-                        std::mem::size_of::<u64>() -
-                        std::mem::size_of::<u64>() -
-                        std::mem::size_of::<u16>() -
-                        std::mem::size_of::<u8>();
+                    let name_len = d.d_reclen as usize
+                        - std::mem::size_of::<u64>()
+                        - std::mem::size_of::<u64>()
+                        - std::mem::size_of::<u16>()
+                        - std::mem::size_of::<u8>();
 
                     // OOB!!!
                     if bpos + name_len > BUFFER_SIZE {
-                        HError::log::<()>(&format!("WARNING: Name for file was out of bounds in: {}",
-                                                   path.to_string_lossy())).ok();
-                        return DentStatus::Err(FileError::GetDents(path.to_string_lossy().to_string()));
+                        HError::log::<()>(&format!(
+                            "WARNING: Name for file was out of bounds in: {}",
+                            path.to_string_lossy()
+                        ))
+                        .ok();
+                        return DentStatus::Err(FileError::GetDents(
+                            path.to_string_lossy().to_string(),
+                        ));
                     }
 
                     // Add length of current dirent to the current offset
@@ -501,11 +496,12 @@ pub fn from_getdents(fd: i32, path: &Path, nothidden: &AtomicUsize)  -> Result<V
                         // Safe as long as d_name is NULL terminated
                         let true_len = unsafe { libc::strlen(d.d_name.as_ptr() as *const i8) };
                         // Safe if strlen returned without SEGFAULT on OOB (if d_name weren't NULL terminated)
-                        let bytes: &[u8] = unsafe { std::slice::from_raw_parts(d.d_name.as_ptr() as *const u8,
-                                                                               true_len) };
+                        let bytes: &[u8] = unsafe {
+                            std::slice::from_raw_parts(d.d_name.as_ptr() as *const u8, true_len)
+                        };
 
                         // Don't want this
-                        if bytes.len() == 0  || bytes == b"." || bytes == b".." {
+                        if bytes.len() == 0 || bytes == b"." || bytes == b".." {
                             continue;
                         }
 
@@ -514,9 +510,8 @@ pub fn from_getdents(fd: i32, path: &Path, nothidden: &AtomicUsize)  -> Result<V
                     };
 
                     // Avoid reallocation on push
-                    let mut pathstr = std::ffi::OsString::with_capacity(path.as_os_str().len() +
-                                                                        name.len() +
-                                                                        2);
+                    let mut pathstr =
+                        std::ffi::OsString::with_capacity(path.as_os_str().len() + name.len() + 2);
                     pathstr.push(path.as_os_str());
                     pathstr.push("/");
                     pathstr.push(name);
@@ -534,37 +529,38 @@ pub fn from_getdents(fd: i32, path: &Path, nothidden: &AtomicUsize)  -> Result<V
                             // Metadata can't be seaved, but at lest
                             // stat is faster with an open fd
                             let flags = nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW;
-                            let stat =
-                                match fstatat(fd, &path, flags) {
-                                    Ok(stat) => stat,
-                                    Err(_) => return DentStatus::Err(FileError::GetDents(path.to_string_lossy()
-                                                                                         .to_string()))
-                                };
+                            let stat = match fstatat(fd, &path, flags) {
+                                Ok(stat) => stat,
+                                Err(_) => {
+                                    return DentStatus::Err(FileError::GetDents(
+                                        path.to_string_lossy().to_string(),
+                                    ))
+                                }
+                            };
 
                             let mode = SFlag::from_bits_truncate(stat.st_mode);
 
                             match mode & SFlag::S_IFMT {
                                 SFlag::S_IFDIR => (Kind::Directory, None),
-                                _ => (Kind::File, None)
+                                _ => (Kind::File, None),
                             }
                         }
                         10 => {
                             // This is a link
-                            let target = nix::fcntl::readlinkat(fd, &path)
-                                .map(PathBuf::from).ok();
-                            let target_kind =
-                                match path.is_dir() {
-                                    true => Kind::Directory,
-                                    false => Kind::File
-                                };
+                            let target = nix::fcntl::readlinkat(fd, &path).map(PathBuf::from).ok();
+                            let target_kind = match path.is_dir() {
+                                true => Kind::Directory,
+                                false => Kind::File,
+                            };
                             (target_kind, target)
                         }
-                        _ => (Kind::File, None)
+                        _ => (Kind::File, None),
                     };
 
-                    let name = name.to_str()
-                                   .map(|n| String::from(n))
-                                   .unwrap_or_else(|| name.to_string_lossy().to_string());
+                    let name = name
+                        .to_str()
+                        .map(|n| String::from(n))
+                        .unwrap_or_else(|| name.to_string_lossy().to_string());
 
                     let hidden = name.as_bytes()[0] == b'.';
 
@@ -598,11 +594,9 @@ pub fn from_getdents(fd: i32, path: &Path, nothidden: &AtomicUsize)  -> Result<V
 
     match result {
         Ok(()) => Ok(std::mem::take(&mut *files.lock().unwrap())),
-        Err(_) => Err(FileError::GetDents(path.to_string_lossy().to_string()))
+        Err(_) => Err(FileError::GetDents(path.to_string_lossy().to_string())),
     }
 }
-
-
 
 impl Files {
     // Use getdents64 on Linux
@@ -612,9 +606,7 @@ impl Files {
 
         let nonhidden = AtomicUsize::default();
 
-        let dir  = Dir::open(path.clone(),
-                             OFlag::O_DIRECTORY,
-                             Mode::empty())
+        let dir = Dir::open(path.clone(), OFlag::O_DIRECTORY, Mode::empty())
             .map_err(|e| FileError::OpenDir(e))?;
 
         let direntries = from_getdents(dir.as_raw_fd(), path, &nonhidden)?;
@@ -626,7 +618,6 @@ impl Files {
         let mut files = Files::default();
         files.directory = File::new_from_path(&path)?;
 
-
         files.files = direntries;
         files.len = nonhidden.load(Ordering::Relaxed);
         files.stale = Some(stale);
@@ -634,21 +625,18 @@ impl Files {
         Ok(files)
     }
 
-
     #[cfg(not(target_os = "linux"))]
     pub fn new_from_path_cancellable(path: &Path, stale: Stale) -> HResult<Files> {
         use std::os::unix::io::AsRawFd;
 
         let nonhidden = AtomicUsize::default();
 
-        let mut dir = Dir::open(path.clone(),
-                                OFlag::O_DIRECTORY,
-                                Mode::empty())
+        let mut dir = Dir::open(path.clone(), OFlag::O_DIRECTORY, Mode::empty())
             .map_err(|e| FileError::OpenDir(e))?;
 
         let dirfd = dir.as_raw_fd();
 
-        let direntries  = dir
+        let direntries = dir
             .iter()
             .stop_stale(stale.clone())
             .map(|f| {
@@ -659,7 +647,7 @@ impl Files {
                 }
                 Ok(f)
             })
-            .collect::<Result<_,_>>()
+            .collect::<Result<_, _>>()
             .map_err(|e| FileError::ReadFiles(e))?;
 
         if stale.is_stale()? {
@@ -681,27 +669,28 @@ impl Files {
 
         let cache = match self.cache.clone() {
             Some(cache) => cache,
-            None => return
+            None => return,
         };
 
-        let mut jobs = self.iter_files_mut()
-                           .collect::<Vec<&mut File>>()
-                           .into_par_iter()
-                           .skip(from)
-                           .take(n)
-                           .filter_map(|f| f.prepare_meta_job(&cache))
-                           .collect::<Vec<_>>();
+        let mut jobs = self
+            .iter_files_mut()
+            .collect::<Vec<&mut File>>()
+            .into_par_iter()
+            .skip(from)
+            .take(n)
+            .filter_map(|f| f.prepare_meta_job(&cache))
+            .collect::<Vec<_>>();
 
         self.jobs.append(&mut jobs);
     }
 
     pub fn run_jobs(&mut self, sender: Sender<Events>) {
         let jobs = std::mem::take(&mut self.jobs);
-        let stale = self.stale
-                        .clone()
-                        .unwrap_or_else(Stale::new);
+        let stale = self.stale.clone().unwrap_or_else(Stale::new);
 
-        if jobs.len() == 0 { return; }
+        if jobs.len() == 0 {
+            return;
+        }
 
         std::thread::spawn(move || {
             let pool = get_pool();
@@ -710,9 +699,7 @@ impl Files {
             start_ticking(sender);
 
             pool.scope_fifo(move |s| {
-                for (path, mslot, dirsize) in jobs.into_iter()
-                                                  .stop_stale(stale.clone())
-                {
+                for (path, mslot, dirsize) in jobs.into_iter().stop_stale(stale.clone()) {
                     s.spawn_fifo(move |_| {
                         if let Some(mslot) = mslot {
                             if let Ok(meta) = std::fs::symlink_metadata(&path) {
@@ -721,9 +708,7 @@ impl Files {
                         }
 
                         if let Some(dirsize) = dirsize {
-                            let size = Dir::open(&path,
-                                                 OFlag::O_DIRECTORY,
-                                                 Mode::empty())
+                            let size = Dir::open(&path, OFlag::O_DIRECTORY, Mode::empty())
                                 .map(|mut d| d.iter().count())
                                 .map_err(|e| FileError::OpenDir(e))
                                 .log_and()
@@ -751,36 +736,33 @@ impl Files {
         self.files.get_mut(index + hidden_in_between)
     }
 
-    pub fn par_iter_files(&self) -> impl ParallelIterator<Item=&File> {
+    pub fn par_iter_files(&self) -> impl ParallelIterator<Item = &File> {
         let filter_fn = self.filter_fn();
 
-        self.files
-            .par_iter()
-            .filter(move |f| filter_fn(f))
+        self.files.par_iter().filter(move |f| filter_fn(f))
     }
 
-    pub fn iter_files(&self) -> impl Iterator<Item=&File> {
+    pub fn iter_files(&self) -> impl Iterator<Item = &File> {
         let filter_fn = self.filter_fn();
 
-        self.files
-            .iter()
-            .filter(move |&f| filter_fn(f))
+        self.files.iter().filter(move |&f| filter_fn(f))
     }
 
     pub fn files_in_between(&self, pos: usize, n_before: usize) -> usize {
         let filter_fn = self.filter_fn();
 
-        self.files[..pos].iter()
-                          .rev()
-                          .enumerate()
-                          .filter(|(_, f)| filter_fn(f))
-                          .take(n_before)
-                          .map(|(i, _)| i + 1)
-                          .last()
-                          .unwrap_or(0)
+        self.files[..pos]
+            .iter()
+            .rev()
+            .enumerate()
+            .filter(|(_, f)| filter_fn(f))
+            .take(n_before)
+            .map(|(i, _)| i + 1)
+            .last()
+            .unwrap_or(0)
     }
 
-    pub fn iter_files_from(&self, from: &File, n_before: usize) -> impl Iterator<Item=&File> {
+    pub fn iter_files_from(&self, from: &File, n_before: usize) -> impl Iterator<Item = &File> {
         let fpos = self.find_file(from).unwrap_or(0);
 
         let files_in_between = self.files_in_between(fpos, n_before);
@@ -792,7 +774,11 @@ impl Files {
             .filter(move |f| filter_fn(f))
     }
 
-    pub fn iter_files_mut_from(&mut self, from: &File, n_before: usize) -> impl Iterator<Item=&mut File> {
+    pub fn iter_files_mut_from(
+        &mut self,
+        from: &File,
+        n_before: usize,
+    ) -> impl Iterator<Item = &mut File> {
         let fpos = self.find_file(from).unwrap_or(0);
         let files_in_between = self.files_in_between(fpos, n_before);
 
@@ -803,12 +789,10 @@ impl Files {
             .filter(move |f| filter_fn(f))
     }
 
-    pub fn iter_files_mut(&mut self) -> impl Iterator<Item=&mut File> {
+    pub fn iter_files_mut(&mut self) -> impl Iterator<Item = &mut File> {
         let filter_fn = self.filter_fn();
 
-        self.files
-            .iter_mut()
-            .filter(move |f| filter_fn(f))
+        self.files.iter_mut().filter(move |f| filter_fn(f))
     }
 
     #[allow(trivial_bounds)]
@@ -818,11 +802,10 @@ impl Files {
         let show_hidden = self.show_hidden;
 
         move |f| {
-            f.kind == Kind::Placeholder ||
-                !(filter.is_some() &&
-                  !f.name.contains(filter.as_ref().unwrap())) &&
-                (!filter_selected || f.selected) &&
-                !(!show_hidden && f.name.starts_with("."))
+            f.kind == Kind::Placeholder
+                || !(filter.is_some() && !f.name.contains(filter.as_ref().unwrap()))
+                    && (!filter_selected || f.selected)
+                    && !(!show_hidden && f.name.starts_with("."))
         }
     }
 
@@ -833,14 +816,11 @@ impl Files {
         let dirs_first = self.dirs_first.clone();
         let sort = self.sort.clone();
 
-        let dircmp = move |a: &File, b: &File| {
-            match (a.is_dir(),  b.is_dir()) {
-                (true, false) if dirs_first => Less,
-                (false, true) if dirs_first => Greater,
-                _ => Equal
-            }
+        let dircmp = move |a: &File, b: &File| match (a.is_dir(), b.is_dir()) {
+            (true, false) if dirs_first => Less,
+            (false, true) if dirs_first => Greater,
+            _ => Equal,
         };
-
 
         let reverse = self.reverse;
         let namecmp = move |a: &File, b: &File| {
@@ -865,10 +845,10 @@ impl Files {
                     let b_meta = b_meta.as_ref().unwrap();
                     match a_meta.size() == b_meta.size() {
                         true => compare(&b.name, &a.name),
-                        false => b_meta.size().cmp(&a_meta.size())
+                        false => b_meta.size().cmp(&a_meta.size()),
                     }
                 }
-                _ => Equal
+                _ => Equal,
             }
         };
 
@@ -885,41 +865,33 @@ impl Files {
                     let b_meta = b_meta.as_ref().unwrap();
                     match a_meta.mtime() == b_meta.mtime() {
                         true => compare(&b.name, &a.name),
-                        false => b_meta.mtime().cmp(&a_meta.mtime())
+                        false => b_meta.mtime().cmp(&a_meta.mtime()),
                     }
                 }
-                _ => Equal
+                _ => Equal,
             }
         };
 
-
         move |a, b| match sort {
-            SortBy::Name => {
-                match dircmp(a, b) {
-                    Equal => namecmp(a, b),
-                    ord @ _ => ord
-                }
+            SortBy::Name => match dircmp(a, b) {
+                Equal => namecmp(a, b),
+                ord @ _ => ord,
             },
-            SortBy::Size => {
-                match dircmp(a, b) {
-                    Equal => sizecmp(a, b),
-                    ord @ _ => ord
-                }
-            }
-            SortBy::MTime => {
-                match dircmp(a, b) {
-                    Equal => timecmp(a, b),
-                    ord @ _ => ord
-                }
-            }
+            SortBy::Size => match dircmp(a, b) {
+                Equal => sizecmp(a, b),
+                ord @ _ => ord,
+            },
+            SortBy::MTime => match dircmp(a, b) {
+                Equal => timecmp(a, b),
+                ord @ _ => ord,
+            },
         }
     }
 
     pub fn sort(&mut self) {
         let sort = self.sorter();
 
-        self.files
-            .par_sort_unstable_by(sort);
+        self.files.par_sort_unstable_by(sort);
     }
 
     pub fn cycle_sort(&mut self) {
@@ -948,11 +920,20 @@ impl Files {
         self.recalculate_len();
     }
 
+    fn remove_placeholder_and_update_files(&mut self, placeholder: &File) -> Option<File> {
+        let position = self
+            .files
+            .iter()
+            .position(|element| *element == *placeholder)?;
+        Some(self.files.remove(position))
+    }
+
     fn remove_placeholder(&mut self) {
         let dirpath = self.directory.path.clone();
-        self.find_file_with_path(&dirpath).cloned()
+        self.find_file_with_path(&dirpath)
+            .cloned()
             .map(|placeholder| {
-                self.files.remove_item(&placeholder);
+                self.remove_placeholder_and_update_files(&placeholder);
                 if self.len > 0 {
                     self.len -= 1;
                 }
@@ -971,7 +952,7 @@ impl Files {
                 self.stale.as_ref().map(|s| s.set_fresh());
                 refresh.pull_async()?;
                 let mut refresh = refresh.value?;
-                self.files = refresh.new_files.take()?;
+                self.files = refresh.new_files.take().ok_or_else(|| HError::NoneError)?;
                 self.jobs.append(&mut refresh.jobs);
                 if refresh.new_len != self.len() {
                     self.len = refresh.new_len;
@@ -982,7 +963,7 @@ impl Files {
             }
         }
 
-        return Ok(None)
+        return Ok(None);
     }
 
     pub fn process_fs_events(&mut self, sender: Sender<Events>) -> HResult<()> {
@@ -998,9 +979,7 @@ impl Files {
                 Ok(refresh)
             });
 
-            refresh.on_ready(move |_,_| {
-                Ok(sender.send(Events::WidgetReady)?)
-            })?;
+            refresh.on_ready(move |_, _| Ok(sender.send(Events::WidgetReady)?))?;
 
             refresh.run()?;
 
@@ -1012,7 +991,11 @@ impl Files {
 
     pub fn path_in_here(&self, path: &Path) -> HResult<bool> {
         let dir = &self.directory.path;
-        let path = if path.is_dir() { path } else { path.parent().unwrap() };
+        let path = if path.is_dir() {
+            path
+        } else {
+            path.parent().unwrap()
+        };
         if dir == path {
             Ok(true)
         } else {
@@ -1022,7 +1005,8 @@ impl Files {
 
     pub fn find_file(&self, file: &File) -> Option<usize> {
         let comp = self.sorter();
-        let pos = self.files
+        let pos = self
+            .files
             .binary_search_by(|probe| comp(probe, file))
             .ok()?;
 
@@ -1069,9 +1053,8 @@ impl Files {
         self.len
     }
 
-    pub fn get_selected(&self) -> impl Iterator<Item=&File> {
-        self.iter_files()
-            .filter(|f| f.is_selected())
+    pub fn get_selected(&self) -> impl Iterator<Item = &File> {
+        self.iter_files().filter(|f| f.is_selected())
     }
 }
 
@@ -1079,7 +1062,7 @@ impl Files {
 pub enum Kind {
     Directory,
     File,
-    Placeholder
+    Placeholder,
 }
 
 impl std::fmt::Display for SortBy {
@@ -1099,7 +1082,6 @@ pub enum SortBy {
     Size,
     MTime,
 }
-
 
 impl PartialEq for File {
     fn eq(&self, other: &File) -> bool {
@@ -1132,7 +1114,6 @@ impl std::default::Default for File {
     }
 }
 
-
 #[derive(Clone)]
 pub struct File {
     pub name: String,
@@ -1147,15 +1128,17 @@ pub struct File {
 }
 
 impl File {
-    pub fn new(
-        name: &str,
-        path: PathBuf) -> File {
+    pub fn new(name: &str, path: PathBuf) -> File {
         let hidden = name.starts_with(".");
 
         File {
             name: name.to_string(),
             hidden: hidden,
-            kind: if path.is_dir() { Kind::Directory } else { Kind::File },
+            kind: if path.is_dir() {
+                Kind::Directory
+            } else {
+                Kind::File
+            },
             path: path,
             dirsize: None,
             target: None,
@@ -1165,9 +1148,7 @@ impl File {
         }
     }
 
-    pub fn new_from_nixentry(direntry: Entry,
-                             path: &Path,
-                             dirfd: i32) -> File {
+    pub fn new_from_nixentry(direntry: Entry, path: &Path, dirfd: i32) -> File {
         // Scary stuff to avoid some of the overhead in Rusts conversions
         // Speedup is a solid ~10%
         let name: &OsStr = unsafe {
@@ -1177,23 +1158,23 @@ impl File {
             let s: &[u8] = s.cast::<&[u8]>().as_ref().unwrap();
             // &Cstr -> &OsStr, minus the NULL byte
             let len = s.len();
-            let s = &s[..len-1] as *const [u8];
+            let s = &s[..len - 1] as *const [u8];
             s.cast::<&OsStr>().as_ref().unwrap()
         };
 
         // Avoid reallocation on push
-        let mut pathstr = std::ffi::OsString::with_capacity(path.as_os_str().len() +
-                                                            name.len() +
-                                                            2);
+        let mut pathstr =
+            std::ffi::OsString::with_capacity(path.as_os_str().len() + name.len() + 2);
         pathstr.push(path.as_os_str());
         pathstr.push("/");
         pathstr.push(name);
 
         let path = PathBuf::from(pathstr);
 
-        let name = name.to_str()
-                       .map(|n| String::from(n))
-                       .unwrap_or_else(|| name.to_string_lossy().to_string());
+        let name = name
+            .to_str()
+            .map(|n| String::from(n))
+            .unwrap_or_else(|| name.to_string_lossy().to_string());
 
         let hidden = name.as_bytes()[0] == b'.';
 
@@ -1202,18 +1183,16 @@ impl File {
                 Type::Directory => (Kind::Directory, None),
                 Type::Symlink => {
                     // Read link target
-                    let target = nix::fcntl::readlinkat(dirfd, &path)
-                        .map(PathBuf::from).ok();
-                    let target_kind =
-                        match path.is_dir() {
-                                    true => Kind::Directory,
-                                    false => Kind::File
-                                };
+                    let target = nix::fcntl::readlinkat(dirfd, &path).map(PathBuf::from).ok();
+                    let target_kind = match path.is_dir() {
+                        true => Kind::Directory,
+                        false => Kind::File,
+                    };
                     (target_kind, target)
                 }
-                _ => (Kind::File, None)
-            }
-            _ => (Kind::Placeholder, None)
+                _ => (Kind::File, None),
+            },
+            _ => (Kind::Placeholder, None),
         };
 
         File {
@@ -1247,7 +1226,11 @@ impl File {
     }
 
     pub fn rename(&mut self, new_path: &Path) -> HResult<()> {
-        self.name = new_path.file_name()?.to_string_lossy().to_string();
+        self.name = new_path
+            .file_name()
+            .ok_or_else(|| HError::NoneError)?
+            .to_string_lossy()
+            .to_string();
         self.path = new_path.into();
         Ok(())
     }
@@ -1257,14 +1240,13 @@ impl File {
     }
 
     pub fn refresh_meta_job(&mut self) -> Job {
-        let meta = self.meta
-            .as_ref()
-            .map_or_else(|| Arc::default(),
-                         |m| {
-                             *m.write().unwrap() = None;
-                             m.clone()
-                         });
-
+        let meta = self.meta.as_ref().map_or_else(
+            || Arc::default(),
+            |m| {
+                *m.write().unwrap() = None;
+                m.clone()
+            },
+        );
 
         (self.path.clone(), Some(meta), None)
     }
@@ -1283,12 +1265,12 @@ impl File {
             None if self.is_dir() => {
                 let dslot = match cache.get_dirsize(self) {
                     Some(dslot) => dslot,
-                    None => cache.make_dirsize(self)
+                    None => cache.make_dirsize(self),
                 };
                 self.set_dirsize(dslot.clone());
                 Some(dslot)
             }
-            _ => None
+            _ => None,
         };
 
         if mslot.is_some() || dslot.is_some() {
@@ -1300,19 +1282,17 @@ impl File {
     }
 
     pub fn meta(&self) -> Option<std::sync::RwLockReadGuard<'_, Option<Metadata>>> {
-        let meta = self.meta
-            .as_ref()?
-            .read()
-            .ok();
+        let meta = self.meta.as_ref()?.read().ok();
 
         match meta {
-            Some(meta) =>
+            Some(meta) => {
                 if meta.is_some() {
                     Some(meta)
                 } else {
                     None
-                },
-            None => None
+                }
+            }
+            None => None,
         }
     }
 
@@ -1321,9 +1301,10 @@ impl File {
         let meta = meta.as_ref()?;
         match COLORS.style_for_path_with_metadata(&self.path, Some(&meta)) {
             // TODO: Also handle bg color, bold, etc.?
-            Some(style) => style.foreground
-                                .as_ref()
-                                .map(|c| crate::term::from_lscolor(&c)),
+            Some(style) => style
+                .foreground
+                .as_ref()
+                .map(|c| crate::term::from_lscolor(&c)),
             None => None,
         }
     }
@@ -1338,18 +1319,17 @@ impl File {
                     } else {
                         return Err(FileError::MetaPending)?;
                     }
-                },
+                }
                 None => (0, ""),
             };
 
             return Ok(size);
         }
 
-
         let mut unit = 0;
         let mut size = match self.meta() {
             Some(meta) => meta.as_ref().unwrap().size(),
-            None => return Err(FileError::MetaPending)?
+            None => return Err(FileError::MetaPending)?,
         };
         while size > 1024 {
             size /= 1024;
@@ -1374,8 +1354,8 @@ impl File {
     // panic with a custom panic hook and handle it gracefully by just
     // doing nothing
     pub fn get_mime(&self) -> HResult<mime_guess::Mime> {
-        use std::panic;
         use crate::fail::MimeError;
+        use std::panic;
 
         if let Some(ext) = self.path.extension() {
             let mime = mime_guess::from_ext(&ext.to_string_lossy()).first();
@@ -1386,7 +1366,7 @@ impl File {
 
         // Take and replace panic handler which does nothing
         let panic_hook = panic::take_hook();
-        panic::set_hook(Box::new(|_| {} ));
+        panic::set_hook(Box::new(|_| {}));
 
         // Catch possible panic caused by tree_magic
         let mime = panic::catch_unwind(|| {
@@ -1397,37 +1377,36 @@ impl File {
         // Restore previous panic handler
         panic::set_hook(panic_hook);
 
-        mime.unwrap_or(None)
-            .ok_or_else(|| {
-                let file = self.name.clone();
-                HError::Mime(MimeError::Panic(file))
-            })
+        mime.unwrap_or(None).ok_or_else(|| {
+            let file = self.name.clone();
+            HError::Mime(MimeError::Panic(file))
+        })
     }
-
 
     pub fn is_text(&self) -> bool {
         tree_magic_fork::match_filepath("text/plain", &self.path)
     }
 
     pub fn is_filtered(&self, filter: &str, filter_selected: bool) -> bool {
-        self.kind == Kind::Placeholder ||
-            !(// filter.is_some() &&
-              !self.name.contains(filter// .as_ref().unwrap()
-              )) &&
-            (!filter_selected || self.selected)
+        self.kind == Kind::Placeholder
+            || !(
+                // filter.is_some() &&
+                !self.name.contains(
+                    filter, // .as_ref().unwrap()
+                )
+            ) && (!filter_selected || self.selected)
     }
 
     pub fn is_hidden(&self) -> bool {
         self.hidden
     }
 
-
     pub fn parent(&self) -> Option<&Path> {
         self.path.parent()
     }
 
     pub fn parent_as_file(&self) -> HResult<File> {
-        let pathbuf = self.parent()?;
+        let pathbuf = self.parent().ok_or_else(|| HError::NoneError)?;
         File::new_from_path(&pathbuf)
     }
 
@@ -1436,7 +1415,7 @@ impl File {
     }
 
     pub fn grand_parent_as_file(&self) -> HResult<File> {
-        let pathbuf = self.grand_parent()?;
+        let pathbuf = self.grand_parent().ok_or_else(|| HError::NoneError)?;
         File::new_from_path(&pathbuf)
     }
 
@@ -1456,7 +1435,7 @@ impl File {
         let base_path = base.path.clone();
         match self.path.strip_prefix(base_path) {
             Ok(path) => PathBuf::from(path),
-            Err(_) => self.path.clone()
+            Err(_) => self.path.clone(),
         }
     }
 
@@ -1483,7 +1462,7 @@ impl File {
     pub fn set_tag_status(&mut self, tags: &[PathBuf]) {
         match tags.contains(&self.path) {
             true => self.tag = Some(true),
-            false => self.tag = Some(false)
+            false => self.tag = Some(false),
         }
     }
 
@@ -1502,7 +1481,9 @@ impl File {
     }
 
     pub fn save_tags(&self) -> HResult<()> {
-        if self.tag.is_none() { return Ok(()); }
+        if self.tag.is_none() {
+            return Ok(());
+        }
 
         let path = self.path.clone();
         let state = self.tag.unwrap();
@@ -1516,24 +1497,25 @@ impl File {
             match state {
                 true => {
                     match tags.1.binary_search(&path) {
-                        Ok(_) => {},
-                        Err(inspos) => tags.1.insert(inspos, path)
+                        Ok(_) => {}
+                        Err(inspos) => tags.1.insert(inspos, path),
                     };
-                },
+                }
                 false => {
                     match tags.1.binary_search(&path) {
-                        Ok(delpos) => { tags.1.remove(delpos); },
+                        Ok(delpos) => {
+                            tags.1.remove(delpos);
+                        }
                         Err(_) => {}
                     };
                 }
             }
 
-            let tagstr = tags.1.iter()
-                               .fold(std::ffi::OsString::new(), |mut s, f| {
-                                   s.push(f);
-                                   s.push("\n");
-                                   s
-                               });
+            let tagstr = tags.1.iter().fold(std::ffi::OsString::new(), |mut s, f| {
+                s.push(f);
+                s.push("\n");
+                s
+            });
 
             std::fs::write(tagfile_path, tagstr.as_bytes())?;
             Ok(())
@@ -1542,15 +1524,23 @@ impl File {
     }
 
     pub fn is_readable(&self) -> HResult<bool> {
-        let meta = self.meta()?;
-        let meta = meta.as_ref()?;
-        let current_user = get_current_username()?.to_string_lossy().to_string();
-        let current_group = get_current_groupname()?.to_string_lossy().to_string();
-        let file_user = get_user_by_uid(meta.uid())?
+        let meta = self.meta().ok_or_else(|| HError::NoneError)?;
+        let meta = meta.as_ref().ok_or_else(|| HError::NoneError)?;
+        let current_user = get_current_username()
+            .ok_or_else(|| HError::NoneError)?
+            .to_string_lossy()
+            .to_string();
+        let current_group = get_current_groupname()
+            .ok_or_else(|| HError::NoneError)?
+            .to_string_lossy()
+            .to_string();
+        let file_user = get_user_by_uid(meta.uid())
+            .ok_or_else(|| HError::NoneError)?
             .name()
             .to_string_lossy()
             .to_string();
-        let file_group = get_group_by_gid(meta.gid())?
+        let file_group = get_group_by_gid(meta.gid())
+            .ok_or_else(|| HError::NoneError)?
             .name()
             .to_string_lossy()
             .to_string();
@@ -1572,11 +1562,11 @@ impl File {
     }
 
     pub fn pretty_print_permissions(&self) -> HResult<String> {
-        let meta = self.meta()?;
-        let meta = meta.as_ref()?;
+        let meta = self.meta().ok_or_else(|| HError::NoneError)?;
+        let meta = meta.as_ref().ok_or_else(|| HError::NoneError)?;
 
         let perms: usize = format!("{:o}", meta.mode()).parse().unwrap();
-        let perms: usize  = perms % 800;
+        let perms: usize = perms % 800;
         let perms = format!("{}", perms);
 
         let r = format!("{}r", crate::term::color_green());
@@ -1584,16 +1574,19 @@ impl File {
         let x = format!("{}x", crate::term::color_red());
         let n = format!("{}-", crate::term::highlight_color());
 
-        let perms = perms.chars().map(|c| match c.to_string().parse().unwrap() {
-            1 => format!("{}{}{}", n,n,x),
-            2 => format!("{}{}{}", n,w,n),
-            3 => format!("{}{}{}", n,w,x),
-            4 => format!("{}{}{}", r,n,n),
-            5 => format!("{}{}{}", r,n,x),
-            6 => format!("{}{}{}", r,w,n),
-            7 => format!("{}{}{}", r,w,x),
-            _ => format!("---")
-        }).collect();
+        let perms = perms
+            .chars()
+            .map(|c| match c.to_string().parse().unwrap() {
+                1 => format!("{}{}{}", n, n, x),
+                2 => format!("{}{}{}", n, w, n),
+                3 => format!("{}{}{}", n, w, x),
+                4 => format!("{}{}{}", r, n, n),
+                5 => format!("{}{}{}", r, n, x),
+                6 => format!("{}{}{}", r, w, n),
+                7 => format!("{}{}{}", r, w, x),
+                _ => format!("---"),
+            })
+            .collect();
 
         Ok(perms)
     }
@@ -1604,11 +1597,11 @@ impl File {
         let uid = meta.uid();
         let file_user = users::get_user_by_uid(uid)?;
         let cur_user = users::get_current_username()?;
-        let color =
-            if file_user.name() == cur_user {
-                crate::term::color_green()
-            } else {
-                crate::term::color_red()  };
+        let color = if file_user.name() == cur_user {
+            crate::term::color_green()
+        } else {
+            crate::term::color_red()
+        };
         Some(format!("{}{}", color, file_user.name().to_string_lossy()))
     }
 
@@ -1618,11 +1611,11 @@ impl File {
         let gid = meta.gid();
         let file_group = users::get_group_by_gid(gid)?;
         let cur_group = users::get_current_groupname()?;
-        let color =
-            if file_group.name() == cur_group {
-                crate::term::color_green()
-            } else {
-                crate::term::color_red()  };
+        let color = if file_group.name() == cur_group {
+            crate::term::color_green()
+        } else {
+            crate::term::color_red()
+        };
         Some(format!("{}{}", color, file_group.name().to_string_lossy()))
     }
 
@@ -1630,8 +1623,7 @@ impl File {
         let meta = self.meta()?;
         let meta = meta.as_ref()?;
 
-        let time: chrono::DateTime<chrono::Local>
-            = chrono::Local.timestamp(meta.mtime(), 0);
+        let time: chrono::DateTime<chrono::Local> = chrono::Local.timestamp(meta.mtime(), 0);
         Some(time.format("%F %R").to_string())
     }
 
@@ -1645,34 +1637,5 @@ impl File {
 
     pub fn short_string(&self) -> String {
         self.path.short_string()
-    }
-}
-
-
-
-// Small wrapper that simplifies stopping with more complex control flow
-pub struct Ticker {
-    invalidated: bool
-}
-
-impl Ticker {
-    pub fn start_ticking(sender: Sender<Events>) -> Self {
-        start_ticking(sender);
-        Ticker {
-            invalidated: false
-        }
-    }
-
-    pub fn stop_ticking(&mut self) {
-        stop_ticking();
-        self.invalidated = true;
-    }
-}
-
-impl Drop for Ticker {
-    fn drop(&mut self) {
-        if !self.invalidated {
-            self.stop_ticking();
-        }
     }
 }

--- a/src/hbox.rs
+++ b/src/hbox.rs
@@ -1,8 +1,8 @@
-use termion::event::{Event};
+use termion::event::Event;
 
+use crate::coordinates::{Coordinates, Position, Size};
+use crate::fail::{ErrorLog, HError, HResult};
 use crate::widget::{Widget, WidgetCore};
-use crate::coordinates::{Coordinates, Size, Position};
-use crate::fail::{HResult, HError, ErrorLog};
 
 #[derive(Debug, PartialEq)]
 pub struct HBox<T: Widget> {
@@ -13,30 +13,36 @@ pub struct HBox<T: Widget> {
     pub active: Option<usize>,
 }
 
-
-impl<T> HBox<T> where T: Widget + PartialEq {
+impl<T> HBox<T>
+where
+    T: Widget + PartialEq,
+{
     pub fn new(core: &WidgetCore) -> HBox<T> {
-        HBox { core: core.clone(),
-               widgets: vec![],
-               ratios: None,
-               zoom_active: false,
-               active: None
-         }
+        HBox {
+            core: core.clone(),
+            widgets: vec![],
+            ratios: None,
+            zoom_active: false,
+            active: None,
+        }
     }
-
 
     pub fn resize_children(&mut self) -> HResult<()> {
         let len = self.widgets.len();
-        if len == 0 { return Ok(()) }
+        if len == 0 {
+            return Ok(());
+        }
 
         if self.zoom_active {
             let coords = self.core.coordinates.clone();
-            self.active_widget_mut()?.set_coordinates(&coords).log();
+            self.active_widget_mut()
+                .ok_or_else(|| HError::NoneError)?
+                .set_coordinates(&coords)
+                .log();
             return Ok(());
         }
 
         let coords: Vec<Coordinates> = self.calculate_coordinates()?;
-
 
         for (widget, coord) in self.widgets.iter_mut().zip(coords.iter()) {
             widget.set_coordinates(coord).log();
@@ -83,14 +89,15 @@ impl<T> HBox<T> where T: Widget + PartialEq {
 
     pub fn calculate_equal_ratios(&self) -> HResult<Vec<usize>> {
         let len = self.widgets.len();
-        if len == 0 { return HError::no_widget(); }
+        if len == 0 {
+            return HError::no_widget();
+        }
 
         let ratios = (0..len).map(|_| 100 / len).collect();
         Ok(ratios)
     }
 
-    pub fn calculate_coordinates(&self)
-                                 -> HResult<Vec<Coordinates>> {
+    pub fn calculate_coordinates(&self) -> HResult<Vec<Coordinates>> {
         let box_coords = self.get_coordinates()?;
         let box_xsize = box_coords.xsize();
         let box_ysize = box_coords.ysize();
@@ -98,56 +105,62 @@ impl<T> HBox<T> where T: Widget + PartialEq {
 
         let mut ratios = match &self.ratios {
             Some(ratios) => ratios.clone(),
-            None => self.calculate_equal_ratios()?
+            None => self.calculate_equal_ratios()?,
         };
 
         let mut ratios_sum: usize = ratios.iter().sum();
 
-        ratios = ratios.iter().map(|&r|
-            (r as f64 * box_xsize as f64 / ratios_sum as f64).round() as usize).collect();
+        ratios = ratios
+            .iter()
+            .map(|&r| (r as f64 * box_xsize as f64 / ratios_sum as f64).round() as usize)
+            .collect();
 
         for r in &mut ratios {
-            if *r < 10 { *r = 10 }
+            if *r < 10 {
+                *r = 10
+            }
         }
 
         ratios_sum = ratios.iter().sum();
 
         while ratios_sum + ratios.len() > box_xsize as usize {
-            let ratios_max = ratios.iter()
-                .position(|&r| r == *ratios.iter().max().unwrap()).unwrap();
+            let ratios_max = ratios
+                .iter()
+                .position(|&r| r == *ratios.iter().max().unwrap())
+                .unwrap();
             ratios[ratios_max] = ratios[ratios_max] - 1;
             ratios_sum -= 1;
         }
 
-        let coords = ratios.iter().fold(Vec::<Coordinates>::new(), |mut coords, ratio| {
-            let len = coords.len();
-            let gap = if len == ratios.len() { 0 } else { 1 };
+        let coords = ratios
+            .iter()
+            .fold(Vec::<Coordinates>::new(), |mut coords, ratio| {
+                let len = coords.len();
+                let gap = if len == ratios.len() { 0 } else { 1 };
 
-            let widget_xsize = *ratio as u16;
-            let widget_xpos = if len == 0 {
-                box_coords.top().x()
-            } else {
-                let prev_coords = coords.last().unwrap();
-                let prev_xsize = prev_coords.xsize();
-                let prev_xpos = prev_coords.position().x();
+                let widget_xsize = *ratio as u16;
+                let widget_xpos = if len == 0 {
+                    box_coords.top().x()
+                } else {
+                    let prev_coords = coords.last().unwrap();
+                    let prev_xsize = prev_coords.xsize();
+                    let prev_xpos = prev_coords.position().x();
 
-                prev_xsize + prev_xpos + gap
-            };
+                    prev_xsize + prev_xpos + gap
+                };
 
-            coords.push(Coordinates {
-                size: Size((widget_xsize,
-                            box_ysize)),
-                position: Position((widget_xpos,
-                                   box_top))
+                coords.push(Coordinates {
+                    size: Size((widget_xsize, box_ysize)),
+                    position: Position((widget_xpos, box_top)),
+                });
+                coords
             });
-            coords
-        });
 
         Ok(coords)
     }
 
     pub fn set_active(&mut self, i: usize) -> HResult<()> {
-        if i+1 > self.widgets.len() {
+        if i + 1 > self.widgets.len() {
             HError::no_widget()?
         }
         self.active = Some(i);
@@ -163,10 +176,10 @@ impl<T> HBox<T> where T: Widget + PartialEq {
     }
 }
 
-
-
-
-impl<T> Widget for HBox<T> where T: Widget + PartialEq {
+impl<T> Widget for HBox<T>
+where
+    T: Widget + PartialEq,
+{
     fn get_core(&self) -> HResult<&WidgetCore> {
         Ok(&self.core)
     }
@@ -180,12 +193,17 @@ impl<T> Widget for HBox<T> where T: Widget + PartialEq {
     }
 
     fn render_header(&self) -> HResult<String> {
-        self.active_widget()?.render_header()
+        self.active_widget()
+            .ok_or_else(|| HError::NoneError)?
+            .render_header()
     }
 
     fn refresh(&mut self) -> HResult<()> {
         if self.zoom_active {
-            self.active_widget_mut()?.refresh().log();
+            self.active_widget_mut()
+                .ok_or_else(|| HError::NoneError)?
+                .refresh()
+                .log();
             return Ok(());
         }
 
@@ -198,20 +216,34 @@ impl<T> Widget for HBox<T> where T: Widget + PartialEq {
 
     fn get_drawlist(&self) -> HResult<String> {
         if self.zoom_active {
-            return self.active_widget()?.get_drawlist();
+            return self
+                .active_widget()
+                .ok_or_else(|| HError::NoneError)?
+                .get_drawlist();
         }
 
-        Ok(self.widgets.iter().map(|child| {
-            child.get_drawlist().log_and().unwrap_or_else(|_| String::new())
-        }).collect())
+        Ok(self
+            .widgets
+            .iter()
+            .map(|child| {
+                child
+                    .get_drawlist()
+                    .log_and()
+                    .unwrap_or_else(|_| String::new())
+            })
+            .collect())
     }
 
     fn on_event(&mut self, event: Event) -> HResult<()> {
-        self.active_widget_mut()?.on_event(event)?;
+        self.active_widget_mut()
+            .ok_or_else(|| HError::NoneError)?
+            .on_event(event)?;
         Ok(())
     }
 
     fn on_key(&mut self, key: termion::event::Key) -> HResult<()> {
-        self.active_widget_mut()?.on_key(key)
+        self.active_widget_mut()
+            .ok_or_else(|| HError::NoneError)?
+            .on_key(key)
     }
 }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -1,8 +1,8 @@
 // Stolen from lsd: https://github.com/Peltoche/lsd
 // Apache License 2.0
 
-use std::path::PathBuf;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub struct Icons {
     icons_by_name: HashMap<&'static str, &'static str>,
@@ -17,13 +17,12 @@ pub struct Icons {
 // s#\\u[0-9a-f]*#\=eval('"'.submatch(0).'"')#
 impl Icons {
     pub fn new() -> Self {
-        let (icons_by_name,
-             icons_by_extension,
-             default_file_icon,
-             default_folder_icon) = (Self::get_default_icons_by_name(),
-                                     Self::get_default_icons_by_extension(),
-                                     "\u{f016}",  // 
-                                     "\u{f115}"); // 
+        let (icons_by_name, icons_by_extension, default_file_icon, default_folder_icon) = (
+            Self::get_default_icons_by_name(),
+            Self::get_default_icons_by_extension(),
+            "\u{f016}", // 
+            "\u{f115}",
+        ); // 
 
         Self {
             icons_by_name,
@@ -34,12 +33,12 @@ impl Icons {
     }
 
     pub fn get(&self, name: &PathBuf) -> &'static str {
-        let file_name = name.file_name()
+        let file_name = name
+            .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or("");
 
-        let extension = name.extension()
-            .and_then(|ext| ext.to_str());
+        let extension = name.extension().and_then(|ext| ext.to_str());
 
         // Check the known names.
         if let Some(icon) = self.icons_by_name.get(file_name) {

--- a/src/imgview.rs
+++ b/src/imgview.rs
@@ -1,14 +1,12 @@
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::io::{BufReader, BufRead};
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use crate::widget::{Widget, WidgetCore};
 use crate::coordinates::Coordinates;
-use crate::fail::{HResult, ErrorCause};
+use crate::fail::{ErrorCause, HError, HResult};
 use crate::mediaview::MediaError;
-
-
+use crate::widget::{Widget, WidgetCore};
 
 lazy_static! {
     static ref PID: AtomicU32 = AtomicU32::new(0);
@@ -39,13 +37,13 @@ impl ImgView {
         let (xpix, ypix) = self.core.coordinates.size_pixels()?;
         let cell_ratio = crate::term::cell_ratio()?;
 
-        let file = &self.file.as_ref()?;
+        let file = &self.file.as_ref().ok_or_else(|| HError::NoneError)?;
         let media_previewer = self.core.config().media_previewer;
         let g_mode = self.core.config().graphics;
 
         let mut previewer = Command::new(&media_previewer)
-            .arg(format!("{}", (xsize+1)))
-            .arg(format!("{}", (ysize+1)))
+            .arg(format!("{}", (xsize + 1)))
+            .arg(format!("{}", (ysize + 1)))
             .arg(format!("{}", xpix))
             .arg(format!("{}", ypix))
             .arg(format!("{}", cell_ratio))
@@ -59,11 +57,13 @@ impl ImgView {
             .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| {
-                let msg = format!("Couldn't run {}{}{}! Error: {:?}",
-                                  crate::term::color_red(),
-                                  media_previewer,
-                                  crate::term::normal_color(),
-                                  &e.kind());
+                let msg = format!(
+                    "Couldn't run {}{}{}! Error: {:?}",
+                    crate::term::color_red(),
+                    media_previewer,
+                    crate::term::normal_color(),
+                    &e.kind()
+                );
 
                 self.core.show_status(&msg).ok();
 
@@ -72,17 +72,13 @@ impl ImgView {
 
         PID.store(previewer.id(), Ordering::Relaxed);
 
-        let stdout = previewer.stdout
-                              .take()
-                              .unwrap();
+        let stdout = previewer.stdout.take().unwrap();
 
         let output = BufReader::new(stdout)
             .lines()
             .collect::<Result<Vec<String>, _>>()?;
 
-        let stderr = previewer.stderr
-                              .take()
-                              .unwrap();
+        let stderr = previewer.stderr.take().unwrap();
 
         let stderr = BufReader::new(stderr)
             .lines()
@@ -94,9 +90,8 @@ impl ImgView {
 
         if !status.success() {
             match status.code() {
-                Some(code) => Err(MediaError::MediaViewerFailed(code,
-                                                                ErrorCause::Str(stderr)))?,
-                None => Err(MediaError::MediaViewerKilled)?
+                Some(code) => Err(MediaError::MediaViewerFailed(code, ErrorCause::Str(stderr)))?,
+                None => Err(MediaError::MediaViewerKilled)?,
             }
         }
 
@@ -114,12 +109,16 @@ impl ImgView {
     }
 
     pub fn kill_running() {
-        use nix::{unistd::Pid,
-                  sys::signal::{kill, Signal}};
+        use nix::{
+            sys::signal::{kill, Signal},
+            unistd::Pid,
+        };
 
         let pid = PID.load(Ordering::Relaxed);
 
-        if pid == 0 { return; }
+        if pid == 0 {
+            return;
+        }
 
         let pid = Pid::from_raw(pid as i32);
         kill(pid, Signal::SIGTERM).ok();
@@ -127,7 +126,6 @@ impl ImgView {
         PID.store(0, Ordering::Relaxed);
     }
 }
-
 
 impl Widget for ImgView {
     fn get_core(&self) -> HResult<&WidgetCore> {
@@ -139,7 +137,9 @@ impl Widget for ImgView {
     }
 
     fn set_coordinates(&mut self, coordinates: &Coordinates) -> HResult<()> {
-        if &self.core.coordinates == coordinates { return Ok(()) }
+        if &self.core.coordinates == coordinates {
+            return Ok(());
+        }
 
         self.core.coordinates = coordinates.clone();
         if self.file.is_some() {
@@ -150,22 +150,21 @@ impl Widget for ImgView {
     }
 
     fn refresh(&mut self) -> HResult<()> {
-
         Ok(())
     }
 
     fn get_drawlist(&self) -> HResult<String> {
         let (xpos, ypos) = self.core.coordinates.position_u();
 
-        let mut draw = self.buffer
-            .iter()
-            .enumerate()
-            .fold(String::new(), |mut draw, (pos, line)| {
-                draw += &format!("{}", crate::term::goto_xy_u(xpos,
-                                                              ypos + pos));
-                draw += line;
-                draw
-            });
+        let mut draw =
+            self.buffer
+                .iter()
+                .enumerate()
+                .fold(String::new(), |mut draw, (pos, line)| {
+                    draw += &format!("{}", crate::term::goto_xy_u(xpos, ypos + pos));
+                    draw += line;
+                    draw
+                });
 
         draw += &format!("{}", termion::style::Reset);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,87 +1,79 @@
-#![feature(vec_remove_item)]
-#![feature(trivial_bounds)]
-#![feature(try_trait)]
 #![allow(dead_code)]
 
 extern crate termion;
 extern crate unicode_width;
 #[macro_use]
 extern crate lazy_static;
+extern crate chrono;
+extern crate clap;
+extern crate dirs_2;
 extern crate failure;
 extern crate failure_derive;
-extern crate natord;
-extern crate dirs_2;
-extern crate lscolors;
-extern crate users;
-extern crate chrono;
-extern crate rayon;
 extern crate libc;
+extern crate lscolors;
+extern crate mime;
+extern crate mime_guess;
+extern crate natord;
 extern crate notify;
 extern crate parse_ansi;
+extern crate rayon;
 extern crate signal_notify;
-extern crate tree_magic_fork;
-extern crate systemstat;
-extern crate mime_guess;
-extern crate mime;
-extern crate clap;
 extern crate strum;
+extern crate systemstat;
+extern crate tree_magic_fork;
+extern crate users;
 #[macro_use]
 extern crate strum_macros;
 #[macro_use]
 extern crate derivative;
+extern crate crossbeam;
 extern crate nix;
 extern crate strip_ansi_escapes;
-extern crate crossbeam;
 
+extern crate async_value;
 extern crate osstrtools;
 extern crate pathbuftools;
-extern crate async_value;
 
-use failure::Fail;
 use clap::{App, Arg};
+use failure::Fail;
 
 use std::panic;
 
+mod bookmarks;
+mod config;
+mod config_installer;
 mod coordinates;
+mod dirty;
+mod fail;
 mod file_browser;
 mod files;
+mod foldview;
+mod fscache;
+mod hbox;
+mod icon;
+mod imgview;
+mod keybind;
 mod listview;
+mod mediaview;
 mod miller_columns;
+mod minibuffer;
+mod paths;
 mod preview;
+mod proclist;
+mod quick_actions;
+mod stats;
+mod tabview;
 mod term;
 mod textview;
-mod widget;
-mod hbox;
-mod tabview;
-mod fail;
-mod minibuffer;
-mod proclist;
-mod bookmarks;
-mod paths;
-mod foldview;
-mod dirty;
-mod fscache;
-mod config;
-mod stats;
-mod icon;
-mod quick_actions;
 mod trait_ext;
-mod config_installer;
-mod imgview;
-mod mediaview;
-mod keybind;
+mod widget;
 
-
-
-
-
-use widget::{Widget, WidgetCore};
-use term::ScreenExt;
-use fail::{HResult, HError, MimeError, ErrorLog};
+use fail::{ErrorLog, HError, HResult, MimeError};
 use file_browser::FileBrowser;
 use tabview::TabView;
+use term::ScreenExt;
 use trait_ext::PathBufMime;
-
+use widget::{Widget, WidgetCore};
 
 fn reset_screen(core: &mut WidgetCore) -> HResult<()> {
     core.screen.suspend()
@@ -143,7 +135,6 @@ fn run(mut core: WidgetCore) -> HResult<()> {
     Ok(())
 }
 
-
 fn parse_args() -> clap::ArgMatches<'static> {
     App::new(clap::crate_name!())
         .version(clap::crate_version!())
@@ -195,16 +186,12 @@ fn parse_args() -> clap::ArgMatches<'static> {
         .get_matches()
 }
 
-
-
 fn process_args(args: clap::ArgMatches, core: WidgetCore) {
     let path = args.value_of("path");
 
     // Just print MIME and quit
     if args.is_present("mime") {
-        get_mime(path)
-            .map_err(|e| eprintln!("{}", e)).
-            ok();
+        get_mime(path).map_err(|e| eprintln!("{}", e)).ok();
         // If we get heres something went wrong.
         std::process::exit(1)
     }
@@ -214,18 +201,11 @@ fn process_args(args: clap::ArgMatches, core: WidgetCore) {
     }
 
     if let Some(path) = path {
-        std::env::set_current_dir(&path)
-            .map_err(HError::from)
-            .log();
+        std::env::set_current_dir(&path).map_err(HError::from).log();
     }
 
     crate::config::set_argv_config(args).log();
 }
-
-
-
-
-
 
 fn get_mime(path: Option<&str>) -> HResult<()> {
     let path = path.ok_or(MimeError::NoFileProvided)?;

--- a/src/mediaview.rs
+++ b/src/mediaview.rs
@@ -1,16 +1,18 @@
+use failure::{self, Fail};
 use lazy_static;
 use termion::event::Key;
-use failure::{self, Fail};
 
-use crate::widget::{Widget, WidgetCore};
-use crate::coordinates::Coordinates;
 use crate::async_value::Stale;
-use crate::fail::{HResult, HError, ErrorLog, ErrorCause};
+use crate::coordinates::Coordinates;
+use crate::fail::{ErrorCause, ErrorLog, HError, HResult};
 use crate::imgview::ImgView;
+use crate::widget::{Widget, WidgetCore};
 
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock,
-                mpsc::{channel, Sender}};
+use std::sync::{
+    mpsc::{channel, Sender},
+    Arc, Mutex, RwLock,
+};
 
 use std::io::{BufRead, BufReader, Write};
 use std::process::Child;
@@ -56,33 +58,42 @@ pub struct MediaView {
     duration: Arc<Mutex<usize>>,
     stale: Stale,
     process: Arc<Mutex<Option<Child>>>,
-    preview_runner: Option<Box<dyn FnOnce(bool,
-                                          bool,
-                                          Arc<Mutex<usize>>,
-                                          Arc<Mutex<usize>>,
-                                          Arc<Mutex<usize>>)
-                                          -> HResult<()> + Send + 'static>>
+    preview_runner: Option<
+        Box<
+            dyn FnOnce(
+                    bool,
+                    bool,
+                    Arc<Mutex<usize>>,
+                    Arc<Mutex<usize>>,
+                    Arc<Mutex<usize>>,
+                ) -> HResult<()>
+                + Send
+                + 'static,
+        >,
+    >,
 }
 
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub enum MediaType {
     Video,
-    Audio
+    Audio,
 }
 
 impl MediaType {
     pub fn to_str(&self) -> &str {
         match self {
             MediaType::Video => "video",
-            MediaType::Audio => "audio"
+            MediaType::Audio => "audio",
         }
     }
 }
 
 impl MediaView {
-    pub fn new_from_file(core: WidgetCore,
-                         file: &Path,
-                         media_type: MediaType) -> HResult<MediaView> {
+    pub fn new_from_file(
+        core: WidgetCore,
+        file: &Path,
+        media_type: MediaType,
+    ) -> HResult<MediaView> {
         let imgview = ImgView {
             core: core.clone(),
             buffer: vec![],
@@ -107,143 +118,143 @@ impl MediaView {
         let media_previewer = core.config().media_previewer;
         let g_mode = core.config().graphics;
 
-        let run_preview = Box::new(move | auto,
-                                   mute,
-                                   height: Arc<Mutex<usize>>,
-                                   position: Arc<Mutex<usize>>,
-                                   duration: Arc<Mutex<usize>>| -> HResult<()> {
-            loop {
-                if tstale.is_stale()? {
-                    return Ok(());
-                }
-
-                // Use current size. Widget could have been resized at some point
-                let (xsize, ysize, xpix, ypix) =
-                {
-                    let view = thread_imgview.lock()?;
-                    let (xsize, ysize) = view.core.coordinates.size_u();
-                    let (xpix, ypix) = view.core.coordinates.size_pixels()?;
-                    (xsize, ysize, xpix, ypix)
-                };
-                let cell_ratio = crate::term::cell_ratio()?;
-
-
-                let mut previewer = std::process::Command::new(&media_previewer)
-                    .arg(format!("{}", (xsize+1)))
-                    // Leave space for position/seek bar
-                    .arg(format!("{}", (ysize-1)))
-                    .arg(format!("{}", xpix))
-                    .arg(format!("{}", ypix))
-                    .arg(format!("{}", cell_ratio))
-                    .arg(format!("{}", ctype.to_str()))
-                    .arg(format!("{}", auto))
-                    .arg(format!("{}", mute))
-                    .arg(format!("{}", g_mode))
-                    .arg(&path)
-                    .stdin(std::process::Stdio::piped())
-                    .stdout(std::process::Stdio::piped())
-                    .stderr(std::process::Stdio::null())
-                    .spawn()
-                    .map_err(|e| {
-                        let msg = format!("Couldn't run {}{}{}! Error: {:?}",
-                                          crate::term::color_red(),
-                                          media_previewer,
-                                          crate::term::normal_color(),
-                                          &e.kind());
-
-                        ccore.show_status(&msg).log();
-
-                        MediaError::NoPreviewer(msg)
-                    })?;
-
-                let mut stdout = BufReader::new(previewer.stdout.take()?);
-                let mut stdin = previewer.stdin.take()?;
-
-                cprocess.lock().map(|mut p| *p = Some(previewer))?;
-
-                let mut frame = vec![];
-                let newline = String::from("\n");
-                let mut line_buf = String::new();
-                let rx_cmd = rx_cmd.clone();
-
-                std::thread::spawn(move || -> HResult<()> {
-                    for cmd in rx_cmd.lock()?.iter() {
-                        write!(stdin, "{}", cmd)?;
-                        write!(stdin, "\n")?;
-                        stdin.flush()?;
-                    }
-                    Ok(())
-                });
-
+        let run_preview = Box::new(
+            move |auto,
+                  mute,
+                  height: Arc<Mutex<usize>>,
+                  position: Arc<Mutex<usize>>,
+                  duration: Arc<Mutex<usize>>|
+                  -> HResult<()> {
                 loop {
-                    // Check if preview-gen finished and break out of loop to restart
-                    if let Ok(Some(code)) = cprocess.lock()?
-                        .as_mut()?
-                        .try_wait() {
-                        if code.success() {
-                            break;
-                        } else {
-                            let msg = String::from("hunter-media failed!");
-                            return Err(failure::format_err!("{}", msg))?;
-                        }
+                    if tstale.is_stale()? {
+                        return Ok(());
                     }
 
+                    // Use current size. Widget could have been resized at some point
+                    let (xsize, ysize, xpix, ypix) = {
+                        let view = thread_imgview.lock()?;
+                        let (xsize, ysize) = view.core.coordinates.size_u();
+                        let (xpix, ypix) = view.core.coordinates.size_pixels()?;
+                        (xsize, ysize, xpix, ypix)
+                    };
+                    let cell_ratio = crate::term::cell_ratio()?;
 
-                    stdout.read_line(&mut line_buf)?;
+                    let mut previewer = std::process::Command::new(&media_previewer)
+                        .arg(format!("{}", (xsize + 1)))
+                        // Leave space for position/seek bar
+                        .arg(format!("{}", (ysize - 1)))
+                        .arg(format!("{}", xpix))
+                        .arg(format!("{}", ypix))
+                        .arg(format!("{}", cell_ratio))
+                        .arg(format!("{}", ctype.to_str()))
+                        .arg(format!("{}", auto))
+                        .arg(format!("{}", mute))
+                        .arg(format!("{}", g_mode))
+                        .arg(&path)
+                        .stdin(std::process::Stdio::piped())
+                        .stdout(std::process::Stdio::piped())
+                        .stderr(std::process::Stdio::null())
+                        .spawn()
+                        .map_err(|e| {
+                            let msg = format!(
+                                "Couldn't run {}{}{}! Error: {:?}",
+                                crate::term::color_red(),
+                                media_previewer,
+                                crate::term::normal_color(),
+                                &e.kind()
+                            );
 
+                            ccore.show_status(&msg).log();
 
-                    // Newline means frame is complete
-                    if line_buf == newline {
-                        let new_height;
+                            MediaError::NoPreviewer(msg)
+                        })?;
 
-                        line_buf.clear();
-                        stdout.read_line(&mut line_buf)?;
-                        let h = line_buf.trim().parse::<usize>()?;
+                    let mut stdout =
+                        BufReader::new(previewer.stdout.take().ok_or_else(|| HError::NoneError)?);
+                    let mut stdin = previewer.stdin.take().ok_or_else(|| HError::NoneError)?;
 
-                        let mut height = height.lock().unwrap();
-                        if *height != h {
-                            new_height = true;
-                        } else {
-                            new_height = false;
+                    cprocess.lock().map(|mut p| *p = Some(previewer))?;
+
+                    let mut frame = vec![];
+                    let newline = String::from("\n");
+                    let mut line_buf = String::new();
+                    let rx_cmd = rx_cmd.clone();
+
+                    std::thread::spawn(move || -> HResult<()> {
+                        for cmd in rx_cmd.lock()?.iter() {
+                            write!(stdin, "{}", cmd)?;
+                            write!(stdin, "\n")?;
+                            stdin.flush()?;
                         }
-                        *height = h;
+                        Ok(())
+                    });
 
-
-                        line_buf.clear();
-                        stdout.read_line(&mut line_buf)?;
-                        let pos = &line_buf.trim();
-                        *position.lock().unwrap() = pos
-                            .parse::<usize>()?;
-
-
-                        line_buf.clear();
-                        stdout.read_line(&mut line_buf)?;
-                        let dur = &line_buf.trim();
-                        *duration.lock().unwrap() = dur
-                            .parse::<usize>()?;
-
-
-                        if let Ok(mut imgview) = thread_imgview.lock() {
-                            if new_height {
-                                imgview.core.clear()?;
+                    loop {
+                        // Check if preview-gen finished and break out of loop to restart
+                        if let Ok(Some(code)) = cprocess
+                            .lock()?
+                            .as_mut()
+                            .ok_or_else(|| HError::NoneError)?
+                            .try_wait()
+                        {
+                            if code.success() {
+                                break;
+                            } else {
+                                let msg = String::from("hunter-media failed!");
+                                return Err(failure::format_err!("{}", msg))?;
                             }
-                            imgview.set_image_data(frame);
-                            sender.send(crate::widget::Events::WidgetReady)
-                                .map_err(|e| HError::from(e))
-                                .log();
                         }
 
-                        line_buf.clear();
-                        frame = vec![];
-                        continue;
-                    } else {
-                        frame.push(line_buf);
-                        line_buf = String::new();
+                        stdout.read_line(&mut line_buf)?;
+
+                        // Newline means frame is complete
+                        if line_buf == newline {
+                            let new_height;
+
+                            line_buf.clear();
+                            stdout.read_line(&mut line_buf)?;
+                            let h = line_buf.trim().parse::<usize>()?;
+
+                            let mut height = height.lock().unwrap();
+                            if *height != h {
+                                new_height = true;
+                            } else {
+                                new_height = false;
+                            }
+                            *height = h;
+
+                            line_buf.clear();
+                            stdout.read_line(&mut line_buf)?;
+                            let pos = &line_buf.trim();
+                            *position.lock().unwrap() = pos.parse::<usize>()?;
+
+                            line_buf.clear();
+                            stdout.read_line(&mut line_buf)?;
+                            let dur = &line_buf.trim();
+                            *duration.lock().unwrap() = dur.parse::<usize>()?;
+
+                            if let Ok(mut imgview) = thread_imgview.lock() {
+                                if new_height {
+                                    imgview.core.clear()?;
+                                }
+                                imgview.set_image_data(frame);
+                                sender
+                                    .send(crate::widget::Events::WidgetReady)
+                                    .map_err(|e| HError::from(e))
+                                    .log();
+                            }
+
+                            line_buf.clear();
+                            frame = vec![];
+                            continue;
+                        } else {
+                            frame.push(line_buf);
+                            line_buf = String::new();
+                        }
                     }
                 }
-            }
-        });
-
+            },
+        );
 
         Ok(MediaView {
             core: core.clone(),
@@ -257,7 +268,7 @@ impl MediaView {
             duration: Arc::new(Mutex::new(0)),
             stale: stale,
             process: process,
-            preview_runner: Some(run_preview)
+            preview_runner: Some(run_preview),
         })
     }
 
@@ -281,11 +292,7 @@ impl MediaView {
                 if !stale.is_stale()? {
                     print!("{}", clear);
 
-                    runner.map(|runner| runner(autoplay,
-                                               mute,
-                                               height,
-                                               position,
-                                               duration).log());
+                    runner.map(|runner| runner(autoplay, mute, height, position, duration).log());
                 }
                 Ok(())
             });
@@ -298,7 +305,7 @@ impl MediaView {
     }
 
     pub fn pause(&self) -> HResult<()> {
-        Ok(self.controller.send(String::from ("a"))?)
+        Ok(self.controller.send(String::from("a"))?)
     }
 
     pub fn progress_bar(&self) -> HResult<String> {
@@ -308,17 +315,19 @@ impl MediaView {
         let duration = self.duration.lock()?.clone();
 
         if duration == 0 || position == 0 {
-            Ok(format!("{:elements$}", "|", elements=xsize))
+            Ok(format!("{:elements$}", "|", elements = xsize))
         } else {
             let element_percent = 100 as f32 / xsize as f32;
             let progress_percent = position as f32 / duration as f32 * 100 as f32;
             let element_count = progress_percent as f32 / element_percent as f32;
 
-            Ok(format!("{:|>elements$}|{: >empty$}",
-                       "",
-                       "",
-                       empty=xsize - (element_count as usize),
-                       elements=element_count as usize))
+            Ok(format!(
+                "{:|>elements$}|{: >empty$}",
+                "",
+                "",
+                empty = xsize - (element_count as usize),
+                elements = element_count as usize
+            ))
         }
     }
 
@@ -343,19 +352,19 @@ impl MediaView {
         let mut icons = String::new();
 
         if *MUTE.read()? == true {
-            icons += &crate::term::goto_xy_u(xpos+xsize-2, ypos+lines);
+            icons += &crate::term::goto_xy_u(xpos + xsize - 2, ypos + lines);
             icons += mute_char;
         } else {
             // Clear the mute symbol, or it doesn't go away
-            icons += &crate::term::goto_xy_u(xpos+xsize-2, ypos+lines);
+            icons += &crate::term::goto_xy_u(xpos + xsize - 2, ypos + lines);
             icons += "  ";
         }
 
         if *AUTOPLAY.read()? == true {
-            icons += &crate::term::goto_xy_u(xpos+xsize-4, ypos+lines);
+            icons += &crate::term::goto_xy_u(xpos + xsize - 4, ypos + lines);
             icons += play_char;
         } else {
-            icons += &crate::term::goto_xy_u(xpos+xsize-4, ypos+lines);
+            icons += &crate::term::goto_xy_u(xpos + xsize - 4, ypos + lines);
             icons += pause_char;
         }
 
@@ -363,9 +372,8 @@ impl MediaView {
     }
 
     pub fn format_secs(&self, secs: usize) -> String {
-        let hours = if secs >= 60*60 { (secs / 60) / 60 } else { 0 };
-        let mins = if secs >= 60 { (secs / 60) %60 } else { 0 };
-
+        let hours = if secs >= 60 * 60 { (secs / 60) / 60 } else { 0 };
+        let mins = if secs >= 60 { (secs / 60) % 60 } else { 0 };
 
         format!("{:02}:{:02}:{:02}", hours, mins, secs % 60)
     }
@@ -383,7 +391,7 @@ impl MediaView {
             self.paused = false;
             self.play()?;
 
-            return Ok(())
+            return Ok(());
         }
         if self.paused {
             self.toggle_autoplay();
@@ -443,12 +451,10 @@ impl MediaView {
     pub fn kill(&mut self) -> HResult<()> {
         let proc = self.process.clone();
         std::thread::spawn(move || -> HResult<()> {
-            proc.lock()?
-                .as_mut()
-                .map(|p| {
-                    p.kill().map_err(|e| HError::from(e)).log();
-                    p.wait().map_err(|e| HError::from(e)).log();
-                });
+            proc.lock()?.as_mut().map(|p| {
+                p.kill().map_err(|e| HError::from(e)).log();
+                p.wait().map_err(|e| HError::from(e)).log();
+            });
             Ok(())
         });
         Ok(())
@@ -465,8 +471,9 @@ impl Widget for MediaView {
     }
 
     fn set_coordinates(&mut self, coordinates: &Coordinates) -> HResult<()> {
-        if &self.core.coordinates == coordinates { return Ok(()); }
-
+        if &self.core.coordinates == coordinates {
+            return Ok(());
+        }
 
         self.core.coordinates = coordinates.clone();
 
@@ -478,12 +485,14 @@ impl Widget for MediaView {
         let (xpix, ypix) = self.core.coordinates.size_pixels()?;
         let cell_ratio = crate::term::cell_ratio()?;
 
-        let xystring = format!("xy\n{}\n{}\n{}\n{}\n{}\n",
-                               xsize+1,
-                               ysize-1,
-                               xpix,
-                               ypix,
-                               cell_ratio);
+        let xystring = format!(
+            "xy\n{}\n{}\n{}\n{}\n{}\n",
+            xsize + 1,
+            ysize - 1,
+            xpix,
+            ypix,
+            cell_ratio
+        );
 
         self.controller.send(xystring)?;
 
@@ -501,16 +510,14 @@ impl Widget for MediaView {
         let progress_str = self.progress_string()?;
         let progress_bar = self.progress_bar()?;
 
-        let frame= self.imgview
-            .lock()
-            .map(|img| img.get_drawlist())?;
+        let frame = self.imgview.lock().map(|img| img.get_drawlist())?;
 
         let mut frame = frame?;
 
-        frame += &crate::term::goto_xy_u(xpos, ypos+height);
+        frame += &crate::term::goto_xy_u(xpos, ypos + height);
         frame += &progress_str;
         frame += &self.get_icons(height)?;
-        frame += &crate::term::goto_xy_u(xpos, ypos+height+1);
+        frame += &crate::term::goto_xy_u(xpos, ypos + height + 1);
         frame += &progress_bar;
 
         Ok(frame)
@@ -529,7 +536,6 @@ impl Drop for MediaView {
         self.core.clear().log();
     }
 }
-
 
 use crate::keybind::*;
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -2,22 +2,22 @@ use dirs_2;
 
 use std::path::PathBuf;
 
-use crate::fail::HResult;
+use crate::fail::{HError, HResult};
 
 pub fn home_path() -> HResult<PathBuf> {
-    let home = dirs_2::home_dir()?;
+    let home = dirs_2::home_dir().ok_or_else(|| HError::NoneError)?;
     Ok(home)
 }
 
 pub fn ranger_path() -> HResult<PathBuf> {
-    let mut ranger_path = dirs_2::config_dir()?;
+    let mut ranger_path = dirs_2::config_dir().ok_or_else(|| HError::NoneError)?;
     ranger_path.push("ranger/");
     Ok(ranger_path)
 }
 
 #[cfg(not(target_os = "macos"))]
 pub fn hunter_path() -> HResult<PathBuf> {
-    let mut hunter_path = dirs_2::config_dir()?;
+    let mut hunter_path = dirs_2::config_dir().ok_or_else(|| HError::NoneError)?;
     hunter_path.push("hunter/");
     Ok(hunter_path)
 }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -1,22 +1,20 @@
 use async_value::{Async, Stale};
 use termion::event::Key;
 
-use std::sync::{Arc, Mutex};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
-use crate::files::{File, Files, Kind, Ticker};
+use crate::coordinates::Coordinates;
+use crate::fail::{ErrorLog, HError, HResult};
+use crate::files::{File, Files, Kind};
 use crate::fscache::FsCache;
-use crate::listview::{ListView, FileSource};
+use crate::imgview::ImgView;
+use crate::listview::{FileSource, ListView};
+use crate::mediaview::MediaView;
 use crate::textview::TextView;
 use crate::widget::{Widget, WidgetCore};
-use crate::coordinates::Coordinates;
-use crate::fail::{HResult, HError, ErrorLog};
-use crate::imgview::ImgView;
-use crate::mediaview::MediaView;
 
-
-pub type AsyncWidgetFn<W> = dyn FnOnce(&Stale, WidgetCore)
-                                       -> HResult<W> + Send + Sync;
+pub type AsyncWidgetFn<W> = dyn FnOnce(&Stale, WidgetCore) -> HResult<W> + Send + Sync;
 
 lazy_static! {
     static ref SUBPROC: Arc<Mutex<Option<u32>>> = Arc::new(Mutex::new(None));
@@ -40,19 +38,14 @@ fn kill_proc() -> HResult<()> {
                 killpg(pid, Signal::SIGTERM).ok();
                 std::thread::sleep(sleep_time);
                 killpg(pid, Signal::SIGKILL).ok();
-            })
-    );
+            }));
     *pid = None;
     Ok(())
 }
 
-
-
-
 impl<W: Widget + Send + 'static> PartialEq for AsyncWidget<W> {
     fn eq(&self, other: &AsyncWidget<W>) -> bool {
-        if self.get_coordinates().unwrap() ==
-            other.get_coordinates().unwrap() {
+        if self.get_coordinates().unwrap() == other.get_coordinates().unwrap() {
             true
         } else {
             false
@@ -63,53 +56,62 @@ impl<W: Widget + Send + 'static> PartialEq for AsyncWidget<W> {
 #[derive(Debug)]
 pub struct AsyncWidget<W: Widget + Send + 'static> {
     pub widget: Async<W>,
-    core: WidgetCore
+    core: WidgetCore,
 }
 
 impl<W: Widget + Send + 'static> AsyncWidget<W> {
-    pub fn new(core: &WidgetCore,
-               closure: impl FnOnce(&Stale) -> HResult<W> + Send + 'static)
-               -> AsyncWidget<W> {
+    pub fn new(
+        core: &WidgetCore,
+        closure: impl FnOnce(&Stale) -> HResult<W> + Send + 'static,
+    ) -> AsyncWidget<W> {
         let sender = Arc::new(Mutex::new(core.get_sender()));
-        let mut widget = Async::new(move |stale|
-                                    closure(stale).map_err(|e| e.into()));
-        widget.on_ready(move |_, stale| {
-            if !stale.is_stale()? {
-                sender.lock().map(|s| s.send(crate::widget::Events::WidgetReady)).ok();
-            }
-            Ok(())
-        }).log();
+        let mut widget = Async::new(move |stale| closure(stale).map_err(|e| e.into()));
+        widget
+            .on_ready(move |_, stale| {
+                crate::files::stop_ticking();
+                if !stale.is_stale()? {
+                    sender
+                        .lock()
+                        .map(|s| s.send(crate::widget::Events::WidgetReady))
+                        .ok();
+                }
+                Ok(())
+            })
+            .log();
 
+        crate::files::start_ticking(core.get_sender());
         widget.run().log();
 
         AsyncWidget {
             widget: widget,
-            core: core.clone()
+            core: core.clone(),
         }
     }
-    pub fn change_to(&mut self,
-                     closure: impl FnOnce(&Stale,
-                                          WidgetCore)
-                                          -> HResult<W> + Send + 'static)
-                     -> HResult<()> {
+    pub fn change_to(
+        &mut self,
+        closure: impl FnOnce(&Stale, WidgetCore) -> HResult<W> + Send + 'static,
+    ) -> HResult<()> {
         self.set_stale().log();
 
         let sender = Mutex::new(self.get_core()?.get_sender());
         let core = self.get_core()?.clone();
 
-        let mut widget = Async::new(move |stale| {
-            Ok(closure(stale, core.clone())?)
-        });
+        let mut widget = Async::new(move |stale| Ok(closure(stale, core.clone())?));
 
-        widget.on_ready(move |_, stale| {
-            if !stale.is_stale()? {
-                sender.lock()
-                    .map(|s| s.send(crate::widget::Events::WidgetReady))
-                    .ok();
-            }
-            Ok(())
-        }).log();
+        widget
+            .on_ready(move |_, stale| {
+                crate::files::stop_ticking();
+                if !stale.is_stale()? {
+                    sender
+                        .lock()
+                        .map(|s| s.send(crate::widget::Events::WidgetReady))
+                        .ok();
+                }
+                Ok(())
+            })
+            .log();
 
+        crate::files::start_ticking(self.core.get_sender());
         widget.run().log();
 
         self.widget = widget;
@@ -144,8 +146,6 @@ impl<W: Widget + Send + 'static> AsyncWidget<W> {
         self.widget().is_ok()
     }
 }
-
-
 
 impl<T: Widget + Send + 'static> Widget for AsyncWidget<T> {
     fn get_core(&self) -> HResult<&WidgetCore> {
@@ -182,30 +182,32 @@ impl<T: Widget + Send + 'static> Widget for AsyncWidget<T> {
             let clear = self.core.get_clearlist()?;
             let (xpos, ypos) = self.get_coordinates()?.u16position();
             let pos = crate::term::goto_xy(xpos, ypos);
-            return Ok(clear + &pos + crate::files::tick_str())
+            return Ok(clear + &pos + crate::files::tick_str());
         }
 
         if self.is_stale()? {
-            return self.core.get_clearlist()
+            return self.core.get_clearlist();
         }
 
         self.widget()?.get_drawlist()
     }
     fn on_key(&mut self, key: termion::event::Key) -> HResult<()> {
-        if self.widget().is_err() { return Ok(()) }
+        if self.widget().is_err() {
+            return Ok(());
+        }
         self.widget_mut()?.on_key(key)
     }
     fn render_footer(&self) -> HResult<String> {
-        if self.widget().is_err() { return Ok(String::new()) }
+        if self.widget().is_err() {
+            return Ok(String::new());
+        }
         self.widget()?.render_footer()
     }
 }
 
-
 impl PartialEq for Previewer {
     fn eq(&self, other: &Previewer) -> bool {
-        if self.widget.get_coordinates().unwrap() ==
-            other.widget.get_coordinates().unwrap() {
+        if self.widget.get_coordinates().unwrap() == other.widget.get_coordinates().unwrap() {
             true
         } else {
             false
@@ -218,27 +220,31 @@ enum PreviewWidget {
     FileList(ListView<Files>),
     TextView(TextView),
     ImgView(ImgView),
-    MediaView(MediaView)
+    MediaView(MediaView),
 }
 
 enum ExtPreviewer {
     Text(PathBuf),
-    Graphics(PathBuf)
+    Graphics(PathBuf),
 }
 
 fn find_previewer(file: &File, g_mode: bool) -> HResult<ExtPreviewer> {
     let path = crate::paths::previewers_path()?;
-    let ext = file.path.extension()?;
+    let ext = file.path.extension().ok_or_else(|| HError::NoneError)?;
 
     // Try to find a graphical previewer first
     if g_mode {
-        let g_previewer = path.read_dir()?
-            .find(|previewer| previewer.as_ref()
-                  .and_then(|p| {
-                      Ok(p.path().file_stem() == Some(ext)
-                         && p.path().extension() == Some(&std::ffi::OsStr::new("g")))
-                  })
-                  .unwrap_or(false))
+        let g_previewer = path
+            .read_dir()?
+            .find(|previewer| {
+                previewer
+                    .as_ref()
+                    .and_then(|p| {
+                        Ok(p.path().file_stem() == Some(ext)
+                            && p.path().extension() == Some(&std::ffi::OsStr::new("g")))
+                    })
+                    .unwrap_or(false)
+            })
             .map(|p| p.map(|p| p.path()));
         match g_previewer {
             Some(Ok(g_p)) => return Ok(ExtPreviewer::Graphics(g_p)),
@@ -246,14 +252,16 @@ fn find_previewer(file: &File, g_mode: bool) -> HResult<ExtPreviewer> {
         }
     }
 
-
-
     // Look for previewers matching the file extension
-    let previewer = path.read_dir()?
-                        .find(|previewer| previewer.as_ref()
-                                   .and_then(|p| Ok(p.file_name() == ext ))
-                                   .unwrap_or(false))
-                        .map(|p| p.map(|p| p.path()));
+    let previewer = path
+        .read_dir()?
+        .find(|previewer| {
+            previewer
+                .as_ref()
+                .and_then(|p| Ok(p.file_name() == ext))
+                .unwrap_or(false)
+        })
+        .map(|p| p.map(|p| p.path()));
     match previewer {
         Some(Ok(p)) => return Ok(ExtPreviewer::Text(p)),
         _ => {
@@ -267,18 +275,18 @@ fn find_previewer(file: &File, g_mode: bool) -> HResult<ExtPreviewer> {
         }
     }
 
-    Ok(ExtPreviewer::Text(previewer??))
+    Ok(ExtPreviewer::Text(
+        previewer.ok_or_else(|| HError::NoneError)??,
+    ))
 }
-
 
 pub struct Previewer {
     widget: AsyncWidget<PreviewWidget>,
     core: WidgetCore,
     file: Option<File>,
     pub cache: FsCache,
-    animator: Stale
+    animator: Stale,
 }
-
 
 impl Previewer {
     pub fn new(core: &WidgetCore, cache: FsCache) -> Previewer {
@@ -289,18 +297,18 @@ impl Previewer {
             Ok(blank)
         });
 
-
-        Previewer { widget: widget,
-                    core: core.clone(),
-                    file: None,
-                    cache: cache,
-                    animator: Stale::new()}
+        Previewer {
+            widget: widget,
+            core: core.clone(),
+            file: None,
+            cache: cache,
+            animator: Stale::new(),
+        }
     }
 
-    fn become_preview(&mut self,
-                      widget: HResult<AsyncWidget<PreviewWidget>>) -> HResult<()> {
+    fn become_preview(&mut self, widget: HResult<AsyncWidget<PreviewWidget>>) -> HResult<()> {
         let coordinates = self.get_coordinates()?.clone();
-        self.widget =  widget?;
+        self.widget = widget?;
         self.widget.set_coordinates(&coordinates)?;
         Ok(())
     }
@@ -324,37 +332,39 @@ impl Previewer {
                 let files = std::mem::take(&mut file_list.content);
                 Ok(files)
             }
-            _ => HError::no_files()?
+            _ => HError::no_files()?,
         }
     }
 
-    pub fn put_preview_files(&mut self,
-                             files: Files,
-                             selected_file: Option<File>) {
+    pub fn put_preview_files(&mut self, files: Files, selected_file: Option<File>) {
         let dir = files.directory.clone();
         let cache = self.cache.clone();
         self.file = Some(dir);
 
-        self.widget.change_to(move |stale, core| {
-            let source = crate::listview::FileSource::Files(files);
+        self.widget
+            .change_to(move |stale, core| {
+                let source = crate::listview::FileSource::Files(files);
 
-            let list = ListView::builder(core.clone(), source)
-                // .prerender()
-                .with_cache(cache)
-                .with_stale(stale.clone())
-                .select(selected_file)
-                .build()?;
+                let list = ListView::builder(core.clone(), source)
+                    // .prerender()
+                    .with_cache(cache)
+                    .with_stale(stale.clone())
+                    .select(selected_file)
+                    .build()?;
 
-            Ok(PreviewWidget::FileList(list))
-        }).log();
+                Ok(PreviewWidget::FileList(list))
+            })
+            .log();
     }
 
-    pub fn set_file(&mut self,
-                    file: &File) -> HResult<()> {
-        if Some(file) == self.file.as_ref() && !self.widget.is_stale()? { return Ok(()) }
+    pub fn set_file(&mut self, file: &File) -> HResult<()> {
+        if Some(file) == self.file.as_ref() && !self.widget.is_stale()? {
+            return Ok(());
+        }
         self.widget.set_stale().ok();
 
-        let same_dir = self.file
+        let same_dir = self
+            .file
             .as_ref()
             .map(|f| f.path.parent() == file.path.parent())
             .unwrap_or(true);
@@ -372,82 +382,60 @@ impl Previewer {
             self.animator.set_stale().ok();
         }
 
-        self.become_preview(Ok(AsyncWidget::new(
-            &self.core,
-            move |stale: &Stale|
-            {
-                kill_proc().log();
-                // Delete files left by graphical PDF previews, etc.
-                if std::path::Path::new("/tmp/hunter-previews").exists() {
-                    std::fs::remove_dir_all("/tmp/hunter-previews/")
-                        .map_err(HError::from)
-                        .log();
-                }
+        self.become_preview(Ok(AsyncWidget::new(&self.core, move |stale: &Stale| {
+            kill_proc().log();
+            // Delete files left by graphical PDF previews, etc.
+            if std::path::Path::new("/tmp/hunter-previews").exists() {
+                std::fs::remove_dir_all("/tmp/hunter-previews/")
+                    .map_err(HError::from)
+                    .log();
+            }
 
-                if file.kind == Kind::Directory  {
-                    let preview = Previewer::preview_dir(&file,
-                                                         cache,
-                                                         &core,
-                                                         &stale,
-                                                         &animator);
-                    return Ok(preview?);
-                }
+            if file.kind == Kind::Directory {
+                let preview = Previewer::preview_dir(&file, cache, &core, &stale, &animator);
+                return Ok(preview?);
+            }
 
-                if let Some(mime) = file.get_mime()
-                                        .log_and()
-                                        .ok()
-                {
-                    let mime_type = mime.type_().as_str();
-                    let is_gif = mime.subtype() == "gif";
-                    let has_media = core.config().media_available();
+            if let Some(mime) = file.get_mime().log_and().ok() {
+                let mime_type = mime.type_().as_str();
+                let is_gif = mime.subtype() == "gif";
+                let has_media = core.config().media_available();
 
-                    match mime_type {
-                        _ if mime_type == "video" || is_gif && has_media => {
-                            let media_type = crate::mediaview::MediaType::Video;
-                            let mediaview = MediaView::new_from_file(core.clone(),
-                                                                     &file.path,
-                                                                     media_type)?;
-                            return Ok(PreviewWidget::MediaView(mediaview));
-                        }
-                        "image" if has_media => {
-                            // Show animation while image is loading, Drop stops it automatically
-                            Ticker::start_ticking(core.get_sender());
-                            let imgview = ImgView::new_from_file(core.clone(),
-                                                                 &file.path())?;
-                            return Ok(PreviewWidget::ImgView(imgview));
-                        }
-                        "audio" if has_media => {
-                            let media_type = crate::mediaview::MediaType::Audio;
-                            let mediaview = MediaView::new_from_file(core.clone(),
-                                                                     &file.path,
-                                                                     media_type)?;
-                            return Ok(PreviewWidget::MediaView(mediaview));
-                        }
-                        "text" if mime.subtype() == "plain" => {
-                            return Ok(Previewer::preview_text(&file,
-                                                              &core,
-                                                              &stale,
-                                                              &animator)?);
-                        }
-                        _ => {
-                            let preview = Previewer::preview_external(&file,
-                                                                      &core,
-                                                                      &stale,
-                                                                      &animator);
-                            if preview.is_ok() {
-                                return Ok(preview?);
-                            }
+                match mime_type {
+                    _ if mime_type == "video" || is_gif && has_media => {
+                        let media_type = crate::mediaview::MediaType::Video;
+                        let mediaview =
+                            MediaView::new_from_file(core.clone(), &file.path, media_type)?;
+                        return Ok(PreviewWidget::MediaView(mediaview));
+                    }
+                    "image" if has_media => {
+                        let imgview = ImgView::new_from_file(core.clone(), &file.path())?;
+                        return Ok(PreviewWidget::ImgView(imgview));
+                    }
+                    "audio" if has_media => {
+                        let media_type = crate::mediaview::MediaType::Audio;
+                        let mediaview =
+                            MediaView::new_from_file(core.clone(), &file.path, media_type)?;
+                        return Ok(PreviewWidget::MediaView(mediaview));
+                    }
+                    "text" if mime.subtype() == "plain" => {
+                        return Ok(Previewer::preview_text(&file, &core, &stale, &animator)?);
+                    }
+                    _ => {
+                        let preview = Previewer::preview_external(&file, &core, &stale, &animator);
+                        if preview.is_ok() {
+                            return Ok(preview?);
                         }
                     }
                 }
+            }
 
-                let mut blank = TextView::new_blank(&core);
-                blank.set_coordinates(&coordinates).log();
-                blank.refresh().log();
-                blank.animate_slide_up(Some(&animator)).log();
-                return Ok(PreviewWidget::TextView(blank))
-
-            })))
+            let mut blank = TextView::new_blank(&core);
+            blank.set_coordinates(&coordinates).log();
+            blank.refresh().log();
+            blank.animate_slide_up(Some(&animator)).log();
+            return Ok(PreviewWidget::TextView(blank));
+        })))
     }
 
     pub fn reload(&mut self) {
@@ -463,20 +451,22 @@ impl Previewer {
         }
     }
 
-
     fn preview_failed<T>(file: &File) -> HResult<T> {
         HError::preview_failed(file)
     }
 
-    fn preview_dir(file: &File,
-                   cache: FsCache,
-                   core: &WidgetCore,
-                   stale: &Stale,
-                   animator: &Stale)
-                   -> HResult<PreviewWidget> {
+    fn preview_dir(
+        file: &File,
+        cache: FsCache,
+        core: &WidgetCore,
+        stale: &Stale,
+        animator: &Stale,
+    ) -> HResult<PreviewWidget> {
         use crate::dirty::Dirtyable;
 
-        if stale.is_stale()? { return Previewer::preview_failed(&file) }
+        if stale.is_stale()? {
+            return Previewer::preview_failed(&file);
+        }
         let source = FileSource::Path(file.clone());
 
         let mut file_list = ListView::builder(core.clone(), source)
@@ -484,7 +474,9 @@ impl Previewer {
             .with_stale(stale.clone())
             .build()?;
 
-        if stale.is_stale()? { return Previewer::preview_failed(&file) }
+        if stale.is_stale()? {
+            return Previewer::preview_failed(&file);
+        }
 
         file_list.animate_slide_up(Some(animator))?;
         file_list.core.set_clean();
@@ -492,29 +484,25 @@ impl Previewer {
         Ok(PreviewWidget::FileList(file_list))
     }
 
-    fn preview_text(file: &File,
-                    core: &WidgetCore,
-                    stale: &Stale,
-                    animator: &Stale)
-                    -> HResult<PreviewWidget> {
-        // Show animation while text is loading
-        let mut ticker = Ticker::start_ticking(core.get_sender());
-
+    fn preview_text(
+        file: &File,
+        core: &WidgetCore,
+        stale: &Stale,
+        animator: &Stale,
+    ) -> HResult<PreviewWidget> {
         let lines = core.coordinates.ysize() as usize;
-
-        let mut textview
-            = TextView::new_from_file_limit_lines(&core,
-                                                  &file,
-                                                  lines)?;
-        if stale.is_stale()? { return Previewer::preview_failed(&file) }
+        let mut textview = TextView::new_from_file_limit_lines(&core, &file, lines)?;
+        if stale.is_stale()? {
+            return Previewer::preview_failed(&file);
+        }
 
         textview.set_coordinates(&core.coordinates)?;
         textview.refresh()?;
 
-        if stale.is_stale()? { return Previewer::preview_failed(&file) }
+        if stale.is_stale()? {
+            return Previewer::preview_failed(&file);
+        }
 
-        // Prevent flicker during slide up
-        ticker.stop_ticking();
         textview.animate_slide_up(Some(animator))?;
         Ok(PreviewWidget::TextView(textview))
     }
@@ -543,62 +531,65 @@ impl Previewer {
             *pid_ = Some(pid);
         }
 
-        if stale.is_stale()? { return Previewer::preview_failed(&file) }
+        if stale.is_stale()? {
+            return Previewer::preview_failed(&file);
+        }
         let output = process.wait_with_output()?;
-        if stale.is_stale()? { return Previewer::preview_failed(&file) }
+        if stale.is_stale()? {
+            return Previewer::preview_failed(&file);
+        }
 
         {
             let mut pid_ = SUBPROC.lock()?;
             *pid_ = None;
         }
 
-
-
         //let status = output.status.code()?;
 
         let output = std::str::from_utf8(&output.stdout)?
             .to_string()
-            .lines().map(|s| s.to_string())
+            .lines()
+            .map(|s| s.to_string())
             .collect();
 
         Ok(output)
     }
 
-    fn preview_external(file: &File,
-                        core: &WidgetCore,
-                        stale: &Stale,
-                        animator: &Stale)
-                        -> HResult<PreviewWidget> {
-        // Show animation while preview is being generated
-        let mut ticker = Ticker::start_ticking(core.get_sender());
-
+    fn preview_external(
+        file: &File,
+        core: &WidgetCore,
+        stale: &Stale,
+        animator: &Stale,
+    ) -> HResult<PreviewWidget> {
         let previewer = if core.config().graphics.as_str() != "unicode" {
-             find_previewer(&file, true)?
+            find_previewer(&file, true)?
         } else {
             find_previewer(&file, false)?
         };
 
         match previewer {
             ExtPreviewer::Text(previewer) => {
-                if stale.is_stale()? { return Previewer::preview_failed(&file) }
+                if stale.is_stale()? {
+                    return Previewer::preview_failed(&file);
+                }
                 let lines = Previewer::run_external(previewer, file, stale)?;
-                if stale.is_stale()? { return Previewer::preview_failed(&file) }
+                if stale.is_stale()? {
+                    return Previewer::preview_failed(&file);
+                }
 
                 let mut textview = TextView::new_blank(&core);
                 textview.set_lines(lines)?;
                 textview.set_coordinates(&core.coordinates).log();
                 textview.refresh().log();
-                // Prevent flicker during slide up
-                ticker.stop_ticking();
                 textview.animate_slide_up(Some(animator)).log();
 
                 Ok(PreviewWidget::TextView(textview))
-            },
+            }
             ExtPreviewer::Graphics(previewer) => {
                 let lines = Previewer::run_external(previewer, file, stale)?;
-                let gfile = lines.first()?;
-                let imgview = ImgView::new_from_file(core.clone(),
-                                                     &PathBuf::from(&gfile))?;
+                let gfile = lines.first().ok_or_else(|| HError::NoneError)?;
+                let imgview = ImgView::new_from_file(core.clone(), &PathBuf::from(&gfile))?;
+
                 Ok(PreviewWidget::ImgView(imgview))
             }
         }
@@ -616,9 +607,7 @@ impl Widget for Previewer {
     fn config_loaded(&mut self) -> HResult<()> {
         use PreviewWidget::*;
 
-        let show_hidden = self.core
-                              .config()
-                              .show_hidden();
+        let show_hidden = self.core.config().show_hidden();
 
         match self.widget.widget_mut() {
             Ok(FileList(filelist)) => {
@@ -627,9 +616,8 @@ impl Widget for Previewer {
                 if setting != show_hidden {
                     self.reload();
                 }
-
             }
-            Ok(_) => {},
+            Ok(_) => {}
             Err(_) => self.reload(),
         }
 
@@ -663,7 +651,7 @@ impl Widget for PreviewWidget {
             PreviewWidget::FileList(widget) => widget.get_core(),
             PreviewWidget::TextView(widget) => widget.get_core(),
             PreviewWidget::ImgView(widget) => widget.get_core(),
-            PreviewWidget::MediaView(widget) => widget.get_core()
+            PreviewWidget::MediaView(widget) => widget.get_core(),
         }
     }
     fn get_core_mut(&mut self) -> HResult<&mut WidgetCore> {
@@ -671,7 +659,7 @@ impl Widget for PreviewWidget {
             PreviewWidget::FileList(widget) => widget.get_core_mut(),
             PreviewWidget::TextView(widget) => widget.get_core_mut(),
             PreviewWidget::ImgView(widget) => widget.get_core_mut(),
-            PreviewWidget::MediaView(widget) => widget.get_core_mut()
+            PreviewWidget::MediaView(widget) => widget.get_core_mut(),
         }
     }
     fn set_coordinates(&mut self, coordinates: &Coordinates) -> HResult<()> {
@@ -687,7 +675,7 @@ impl Widget for PreviewWidget {
             PreviewWidget::FileList(widget) => widget.refresh(),
             PreviewWidget::TextView(widget) => widget.refresh(),
             PreviewWidget::ImgView(widget) => widget.refresh(),
-            PreviewWidget::MediaView(widget) => widget.refresh()
+            PreviewWidget::MediaView(widget) => widget.refresh(),
         }
     }
     fn get_drawlist(&self) -> HResult<String> {
@@ -695,7 +683,7 @@ impl Widget for PreviewWidget {
             PreviewWidget::FileList(widget) => widget.get_drawlist(),
             PreviewWidget::TextView(widget) => widget.get_drawlist(),
             PreviewWidget::ImgView(widget) => widget.get_drawlist(),
-            PreviewWidget::MediaView(widget) => widget.get_drawlist()
+            PreviewWidget::MediaView(widget) => widget.get_drawlist(),
         }
     }
 
@@ -704,7 +692,7 @@ impl Widget for PreviewWidget {
             PreviewWidget::FileList(widget) => widget.render_footer(),
             PreviewWidget::TextView(widget) => widget.render_footer(),
             PreviewWidget::ImgView(widget) => widget.render_footer(),
-            PreviewWidget::MediaView(widget) => widget.render_footer()
+            PreviewWidget::MediaView(widget) => widget.render_footer(),
         }
     }
 
@@ -713,13 +701,15 @@ impl Widget for PreviewWidget {
             PreviewWidget::FileList(widget) => widget.on_key(key),
             PreviewWidget::TextView(widget) => widget.on_key(key),
             PreviewWidget::ImgView(widget) => widget.on_key(key),
-            PreviewWidget::MediaView(widget) => widget.on_key(key)
+            PreviewWidget::MediaView(widget) => widget.on_key(key),
         }
     }
 }
 
-
-impl<T> Widget for Box<T> where T: Widget + ?Sized {
+impl<T> Widget for Box<T>
+where
+    T: Widget + ?Sized,
+{
     fn get_core(&self) -> HResult<&WidgetCore> {
         Ok((**self).get_core()?)
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,19 +1,21 @@
-use systemstat::{System, Platform};
 use systemstat::data::Filesystem;
+use systemstat::{Platform, System};
 
-use std::path::{Path, PathBuf, Component};
 use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
 
-use crate::fail::{HResult, ErrorLog};
+use crate::fail::{ErrorLog, HError, HResult};
 
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub struct FsStat {
-    pub stats: HashMap<PathBuf, Filesystem>
+    pub stats: HashMap<PathBuf, Filesystem>,
 }
 
 impl FsStat {
     pub fn new() -> HResult<FsStat> {
-        let mut stats = FsStat { stats: HashMap::new() };
+        let mut stats = FsStat {
+            stats: HashMap::new(),
+        };
         stats.refresh().log();
 
         Ok(stats)
@@ -23,7 +25,8 @@ impl FsStat {
         let sys = System::new();
         let mounts = sys.mounts()?;
 
-        let stats = mounts.into_iter()
+        let stats = mounts
+            .into_iter()
             .fold(HashMap::new(), |mut stats, mount: Filesystem| {
                 let path = PathBuf::from(&mount.fs_mounted_on);
                 stats.insert(path, mount);
@@ -42,17 +45,19 @@ impl FsStat {
             .filter(|mount_point| path.starts_with(&mount_point))
             .collect::<Vec<&PathBuf>>();
 
-        let deepest_match = candidates.iter()
-            .fold(PathBuf::new(), |mut deepest, path| {
-                let curren_path_len = deepest.components().count();
-                let candidate_path_len = path.components().count();
+        let deepest_match = candidates.iter().fold(PathBuf::new(), |mut deepest, path| {
+            let curren_path_len = deepest.components().count();
+            let candidate_path_len = path.components().count();
 
-                if candidate_path_len >  curren_path_len {
-                    deepest = path.to_path_buf();
-                }
-               deepest
-            });
-        let fs = self.stats.get(&deepest_match)?;
+            if candidate_path_len > curren_path_len {
+                deepest = path.to_path_buf();
+            }
+            deepest
+        });
+        let fs = self
+            .stats
+            .get(&deepest_match)
+            .ok_or_else(|| HError::NoneError)?;
         Ok(fs)
     }
 }
@@ -70,7 +75,7 @@ impl FsExt for Filesystem {
         let dev = match dev {
             Component::Normal(dev) => dev.to_string_lossy().to_string() + ": ",
             // zfs on FBSD doesn't return a device path
-            _ => "".to_string()
+            _ => "".to_string(),
         };
         Some(dev)
     }
@@ -82,6 +87,4 @@ impl FsExt for Filesystem {
     fn get_free(&self) -> String {
         self.avail.to_string_as(false)
     }
-
-
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,14 +1,14 @@
-use std::io::{Stdout, Write, BufWriter, BufRead};
+use std::io::{BufRead, BufWriter, Stdout, Write};
 use std::sync::{Arc, Mutex, RwLock};
 
 use termion;
-use termion::screen::AlternateScreen;
 use termion::raw::{IntoRawMode, RawTerminal};
+use termion::screen::AlternateScreen;
 
+use crate::unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use parse_ansi::parse_bytes;
-use crate::unicode_width::{UnicodeWidthStr, UnicodeWidthChar};
 
-use crate::fail::{HResult, ErrorLog};
+use crate::fail::{ErrorLog, HError, HResult};
 use crate::trait_ext::ExtractResult;
 
 pub type TermMode = AlternateScreen<RawTerminal<BufWriter<Stdout>>>;
@@ -17,7 +17,7 @@ pub type TermMode = AlternateScreen<RawTerminal<BufWriter<Stdout>>>;
 pub struct Screen {
     screen: Arc<Mutex<TermMode>>,
     size: Arc<RwLock<Option<(usize, usize)>>>,
-    terminal: String
+    terminal: String,
 }
 
 impl Screen {
@@ -30,7 +30,7 @@ impl Screen {
         Ok(Screen {
             screen: Arc::new(Mutex::new(screen)),
             size: Arc::new(RwLock::new(None)),
-            terminal: terminal
+            terminal: terminal,
         })
     }
 
@@ -46,19 +46,20 @@ impl Screen {
     pub fn get_size(&self) -> HResult<(usize, usize)> {
         match self.size.read()?.clone() {
             Some((xsize, ysize)) => Ok((xsize, ysize)),
-            None => Ok((self.xsize()?, self.ysize()?))
+            None => Ok((self.xsize()?, self.ysize()?)),
         }
     }
 
     pub fn take_size(&self) -> HResult<(usize, usize)> {
-        Ok(self.size.write()?.take()?)
+        Ok(self.size.write()?.take().ok_or_else(|| HError::NoneError)?)
     }
 
     pub fn set_title(&mut self, title: &str) -> HResult<()> {
-        if self.terminal.starts_with("xterm") ||
-            self.terminal.starts_with("screen") ||
-            self.terminal.starts_with("tmux"){
-             write!(self, "\x1b]2;hunter: {}\x1b\\", title)?;
+        if self.terminal.starts_with("xterm")
+            || self.terminal.starts_with("screen")
+            || self.terminal.starts_with("tmux")
+        {
+            write!(self, "\x1b]2;hunter: {}\x1b\\", title)?;
         }
         if self.terminal.starts_with("tmux") {
             write!(self, "\x1bkhunter: {}\x1b\\", title)?;
@@ -71,15 +72,13 @@ impl Write for Screen {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.screen
             .lock()
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other,
-                                             "Screen Mutex poisoned!"))
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Screen Mutex poisoned!"))
             .and_then(|mut s| s.write(buf))
     }
     fn flush(&mut self) -> std::io::Result<()> {
         self.screen
             .lock()
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other,
-                                             "Screen Mutex poisoned!"))
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Screen Mutex poisoned!"))
             .and_then(|mut s| s.flush())
     }
 }
@@ -112,9 +111,7 @@ pub trait ScreenExt: Write {
         Ok(())
     }
     fn clear(&mut self) -> HResult<()> {
-        write!(self, "{}{}",
-               termion::style::Reset,
-               termion::clear::All)?;
+        write!(self, "{}{}", termion::style::Reset, termion::clear::All)?;
         Ok(())
     }
     fn write_str(&mut self, str: &str) -> HResult<()> {
@@ -129,7 +126,7 @@ pub trait ScreenExt: Write {
     }
     fn size(&self) -> HResult<(usize, usize)> {
         let (xsize, ysize) = termion::terminal_size()?;
-        Ok(((xsize-1) as usize, (ysize-1) as usize))
+        Ok(((xsize - 1) as usize, (ysize - 1) as usize))
     }
 
     fn xsize(&self) -> HResult<usize> {
@@ -154,15 +151,11 @@ pub trait ScreenExt: Write {
 
 impl ScreenExt for Screen {
     fn suspend_raw_mode(&mut self) -> HResult<()> {
-        self.screen
-            .lock()?
-            .suspend_raw_mode()
+        self.screen.lock()?.suspend_raw_mode()
     }
 
     fn activate_raw_mode(&mut self) -> HResult<()> {
-        self.screen
-            .lock()?
-            .activate_raw_mode()
+        self.screen.lock()?.activate_raw_mode()
     }
 }
 
@@ -201,7 +194,7 @@ pub fn ysize() -> u16 {
 
 pub fn size() -> HResult<(usize, usize)> {
     let (xsize, ysize) = termion::terminal_size()?;
-    Ok(((xsize-1) as usize, (ysize-1) as usize))
+    Ok(((xsize - 1) as usize, (ysize - 1) as usize))
 }
 
 pub fn size_pixels() -> HResult<(usize, usize)> {
@@ -213,31 +206,32 @@ pub fn cell_ratio() -> HResult<f32> {
     let (xsize, ysize) = size()?;
     let (xpix, ypix) = size_pixels()?;
 
-    let cell_xpix = xpix as f32 / (xsize+1) as f32;
-    let cell_ypix = ypix as f32 / (ysize+1) as f32;
+    let cell_xpix = xpix as f32 / (xsize + 1) as f32;
+    let cell_ypix = ypix as f32 / (ysize + 1) as f32;
     let ratio = cell_xpix / cell_ypix;
 
     Ok(ratio)
 }
 
 pub fn sized_string(string: &str, xsize: u16) -> &str {
-    let len = string.chars()
-                    .map(|ch| {
-                        if ch.is_ascii() {
-                            (1, 1)
-                        } else {
-                            (UnicodeWidthChar::width(ch).unwrap_or(0), ch.len_utf8())
-                        }
-                    })
-                    .scan((0,0), |(str_width, str_len), (ch_width, ch_len)| {
-                        *str_width += ch_width;
-                        *str_len += ch_len;
-                        Some((*str_width, *str_len))
-                    })
-                    .take_while(|(str_width, _)| *str_width < xsize as usize)
-                    .map(|(_, str_len)| str_len)
-                    .last()
-                    .unwrap_or(0);
+    let len = string
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii() {
+                (1, 1)
+            } else {
+                (UnicodeWidthChar::width(ch).unwrap_or(0), ch.len_utf8())
+            }
+        })
+        .scan((0, 0), |(str_width, str_len), (ch_width, ch_len)| {
+            *str_width += ch_width;
+            *str_len += ch_len;
+            Some((*str_width, *str_len))
+        })
+        .take_while(|(str_width, _)| *str_width < xsize as usize)
+        .map(|(_, str_len)| str_len)
+        .last()
+        .unwrap_or(0);
 
     &string[0..len]
 }
@@ -245,12 +239,12 @@ pub fn sized_string(string: &str, xsize: u16) -> &str {
 #[derive(Debug)]
 enum Token<'a> {
     Text(&'a str),
-    Ansi(&'a str)
+    Ansi(&'a str),
 }
 
 fn get_tokens(string: &str) -> Vec<Token> {
-    let mut tokens = parse_bytes(string.as_bytes())
-        .fold((Vec::new(), 0), |(mut tokens, last_tok), ansi_pos| {
+    let mut tokens =
+        parse_bytes(string.as_bytes()).fold((Vec::new(), 0), |(mut tokens, last_tok), ansi_pos| {
             if last_tok == 0 {
                 // first iteration
                 if ansi_pos.start() != 0 {
@@ -282,77 +276,70 @@ fn get_tokens(string: &str) -> Vec<Token> {
 pub fn string_len(string: &str) -> usize {
     let tokens = get_tokens(&string);
 
-    tokens.iter().fold(0, |len, token| {
-        match token {
-            Token::Text(text) => len + text.len(),
-            _ => len
-        }
+    tokens.iter().fold(0, |len, token| match token {
+        Token::Text(text) => len + text.len(),
+        _ => len,
     })
 }
-
 
 pub fn sized_string_u(string: &str, xsize: usize) -> String {
     let tokens = get_tokens(&string);
 
-    let sized = tokens.iter().try_fold((String::new(), 0), |(mut sized, width), token| {
-        let (tok, tok_width) = match token {
-            Token::Text(text) => {
-                let tok_str = text;
-                let tok_width = text.width();
-                (tok_str, tok_width)
-            },
-            Token::Ansi(ansi) => (ansi, 0)
-        };
-
-        // adding this token makes string larger than xsise
-        if width + tok_width > xsize {
-            let chars_left = xsize + 1 - width;
-
-            // fill up with chars from token until xsize is reached
-            let fillup = tok.chars().try_fold((String::new(), 0),
-                                              |(mut fillup, fillup_width), chr| {
-                let chr_width = chr.width().unwrap_or(0);
-
-                if fillup_width + chr_width > chars_left {
-                    Err((fillup, fillup_width))
-                } else {
-                    fillup.push(chr);
-                    Ok((fillup, fillup_width + chr_width))
+    let sized = tokens
+        .iter()
+        .try_fold((String::new(), 0), |(mut sized, width), token| {
+            let (tok, tok_width) = match token {
+                Token::Text(text) => {
+                    let tok_str = text;
+                    let tok_width = text.width();
+                    (tok_str, tok_width)
                 }
-            });
+                Token::Ansi(ansi) => (ansi, 0),
+            };
 
-            let (fillup, fillup_width) = fillup.extract();
-            sized.push_str(&fillup);
+            // adding this token makes string larger than xsise
+            if width + tok_width > xsize {
+                let chars_left = xsize + 1 - width;
 
-            // we're done here, stop looping
-            Err((sized, width + fillup_width))
-        } else {
-            sized.push_str(&tok);
-            Ok((sized, width + tok_width))
-        }
+                // fill up with chars from token until xsize is reached
+                let fillup =
+                    tok.chars()
+                        .try_fold((String::new(), 0), |(mut fillup, fillup_width), chr| {
+                            let chr_width = chr.width().unwrap_or(0);
 
-    });
+                            if fillup_width + chr_width > chars_left {
+                                Err((fillup, fillup_width))
+                            } else {
+                                fillup.push(chr);
+                                Ok((fillup, fillup_width + chr_width))
+                            }
+                        });
 
+                let (fillup, fillup_width) = fillup.extract();
+                sized.push_str(&fillup);
+
+                // we're done here, stop looping
+                Err((sized, width + fillup_width))
+            } else {
+                sized.push_str(&tok);
+                Ok((sized, width + tok_width))
+            }
+        });
 
     let (mut sized_str, sized_width) = sized.extract();
 
     // pad out string
     if sized_width < xsize {
-        let padding = xsize-sized_width;
+        let padding = xsize - sized_width;
         for _ in 0..padding {
             sized_str += " ";
         }
     }
 
-
     sized_str
 }
 
-
 // Do these as constants
-
-
-
 
 pub fn highlight_color() -> String {
     format!(
@@ -395,31 +382,20 @@ pub fn color_light_yellow() -> String {
 }
 
 pub fn color_orange() -> String {
-    let color = termion::color::Fg(termion::color::AnsiValue::rgb(5 as u8 ,
-                                                                  4 as u8,
-                                                                  0 as u8));
+    let color = termion::color::Fg(termion::color::AnsiValue::rgb(5 as u8, 4 as u8, 0 as u8));
     format!("{}", color)
 }
 
-
 pub fn from_lscolor(color: &lscolors::Color) -> String {
     match color {
-        lscolors::Color::Black
-            => format!("{}", termion::color::Fg(termion::color::Black)),
-        lscolors::Color::Red
-            => format!("{}", termion::color::Fg(termion::color::Red)),
-        lscolors::Color::Green
-            => format!("{}", termion::color::Fg(termion::color::Green)),
-        lscolors::Color::Yellow
-            => format!("{}", termion::color::Fg(termion::color::Yellow)),
-        lscolors::Color::Blue
-            => format!("{}", termion::color::Fg(termion::color::Blue)),
-        lscolors::Color::Magenta
-            => format!("{}", termion::color::Fg(termion::color::Magenta)),
-        lscolors::Color::Cyan
-            => format!("{}", termion::color::Fg(termion::color::Cyan)),
-        lscolors::Color::White
-            => format!("{}", termion::color::Fg(termion::color::White)),
+        lscolors::Color::Black => format!("{}", termion::color::Fg(termion::color::Black)),
+        lscolors::Color::Red => format!("{}", termion::color::Fg(termion::color::Red)),
+        lscolors::Color::Green => format!("{}", termion::color::Fg(termion::color::Green)),
+        lscolors::Color::Yellow => format!("{}", termion::color::Fg(termion::color::Yellow)),
+        lscolors::Color::Blue => format!("{}", termion::color::Fg(termion::color::Blue)),
+        lscolors::Color::Magenta => format!("{}", termion::color::Fg(termion::color::Magenta)),
+        lscolors::Color::Cyan => format!("{}", termion::color::Fg(termion::color::Cyan)),
+        lscolors::Color::White => format!("{}", termion::color::Fg(termion::color::White)),
         _ => format!("{}", normal_color()),
     }
 }
@@ -437,8 +413,8 @@ pub fn goto_xy(x: u16, y: u16) -> String {
 }
 
 pub fn goto_xy_u(x: usize, y: usize) -> String {
-    let x = (x+1) as u16;
-    let y = (y+1) as u16;
+    let x = (x + 1) as u16;
+    let y = (y + 1) as u16;
     format!("{}", termion::cursor::Goto(x, y))
 }
 

--- a/src/trait_ext.rs
+++ b/src/trait_ext.rs
@@ -3,28 +3,19 @@ use std::path::PathBuf;
 use crate::fail::{HResult, MimeError};
 use crate::files::File;
 
-
-
-
-
-
-
-
-
 // This makes using short-circuiting iterators more convenient
 pub trait ExtractResult<T> {
     fn extract(self) -> T;
 }
 
-impl<T> ExtractResult<T> for Result<T,T> {
+impl<T> ExtractResult<T> for Result<T, T> {
     fn extract(self) -> T {
         match self {
             Ok(val) => val,
-            Err(val) => val
+            Err(val) => val,
         }
     }
 }
-
 
 // To get MIME from Path without hassle
 pub trait PathBufMime {
@@ -33,13 +24,10 @@ pub trait PathBufMime {
 
 impl PathBufMime for PathBuf {
     fn get_mime(&self) -> HResult<String> {
-        let file = File::new_from_path(&self)
-            .map_err(|e| MimeError::AccessFailed(Box::new(e)))?;
+        let file = File::new_from_path(&self).map_err(|e| MimeError::AccessFailed(Box::new(e)))?;
 
         file.get_mime()
-            .map(|mime| {
-                Ok(format!("{}", mime))
-            })
+            .map(|mime| Ok(format!("{}", mime)))
             .map_err(|_| MimeError::NoMimeFound)?
     }
 }


### PR DESCRIPTION
Remove dependencies on nightly build of rust compiler. #89 
1.  `vec_remove_item`
2. `std::options::NoneError`
Also, I formatted it using rustfmt, hence the reason for large amount of diff. 