### PR TITLE
hunter rust stable

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,26 +1,10 @@
 extern crate termion;
 extern crate rustc_version;
 
-use rustc_version::{version_meta, Channel};
-
 // use std::process::Command;
 
 
 fn main() -> Result<(),()> {
-    // Bail out if compiler isn't a nightly
-    if let Ok(false) = version_meta().map(|m| m.channel == Channel::Nightly) {
-        eprint!("{}", termion::color::Fg(termion::color::Red));
-        eprint!("{}", termion::style::Bold);
-        eprint!("{}", termion::style::Underline);
-        eprintln!("NIHGTLY COMPILER required");
-        eprintln!("Please install a nighlty compiler to proceed: https://rustup.rs/");
-        eprint!("{}", termion::style::Reset);
-        eprintln!("rustup toolchain install nightly");
-        eprintln!("source ~/.cargo/env");
-
-        return Err(());
-    }
-
     // crates.io doesn't allow question marks in file names
     // So we just stuff that in an archive for distribution
 

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -24,7 +24,7 @@ impl Bookmarks {
         Ok(())
     }
     pub fn get(&self, key: char) -> HResult<&String> {
-        let path = self.mapping.get(&key)?;
+        let path = self.mapping.get(&key).ok_or_else(|| HError::NoneError)?;
         Ok(path)
     }
     pub fn load(&mut self) -> HResult<()> {
@@ -105,7 +105,7 @@ impl BMPopup {
         self.get_core()?.clear()?;
 
         let bookmark = self.bookmark_path.take();
-        Ok(bookmark?)
+        Ok(bookmark.ok_or_else(|| HError::NoneError)?)
     }
 
     pub fn add(&mut self, path: &str) -> HResult<()> {
@@ -169,7 +169,7 @@ impl Widget for BMPopup {
         let mut drawlist = String::new();
 
         if !self.add_mode {
-            let cwd = self.bookmark_path.as_ref()?;
+            let cwd = self.bookmark_path.as_ref().ok_or_else(|| HError::NoneError)?;
             drawlist += &self.render_line(ypos, &'`', cwd);
         }
 
@@ -191,7 +191,7 @@ impl Widget for BMPopup {
             Key::Char('`') => return HError::popup_finnished(),
             Key::Char(key) => {
                 if self.add_mode {
-                    let path = self.bookmark_path.take()?;
+                    let path = self.bookmark_path.take().ok_or_else(|| HError::NoneError)?;
                     self.bookmarks.add(key, &path)?;
                     self.add_mode = false;
                     self.bookmarks.save().log();

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,7 +93,7 @@ pub struct Config {
     pub media_mute: bool,
     pub media_previewer: String,
     pub media_previewer_exists: bool,
-    pub ratios: Vec::<usize>,
+    pub ratios: Vec<usize>,
     pub graphics: String,
     pub keybinds: KeyBinds,
 }

--- a/src/config_installer.rs
+++ b/src/config_installer.rs
@@ -60,7 +60,7 @@ fn has_config() -> HResult<bool> {
 
 fn install_config_all() -> HResult<()> {
     let hunter_dir = crate::paths::hunter_path()?;
-    let config_dir = hunter_dir.parent()?;
+    let config_dir = hunter_dir.parent().ok_or_else(|| HError::NoneError)?;
 
     if !hunter_dir.exists() {
         // create if non-existing
@@ -156,7 +156,7 @@ pub fn update_config(core: WidgetCore, force: bool) -> HResult<()> {
 fn update_dir<P: AsRef<Path>>(source: P, target: P) -> HResult<()> {
     for file in std::fs::read_dir(source)? {
         let file_path = file?.path();
-        let file_name = file_path.file_name()?;
+        let file_name = file_path.file_name().ok_or_else(|| HError::NoneError)?;
         let target_path = target.as_ref().join(file_name);
 
         if file_path.is_dir() {

--- a/src/fail.rs
+++ b/src/fail.rs
@@ -327,12 +327,12 @@ impl<T> From<std::sync::TryLockError<T>> for HError {
     }
 }
 
-impl From<std::option::NoneError> for HError {
-    fn from(_error: std::option::NoneError) -> Self {
-        let err = HError::NoneError;
-        err
-    }
-}
+// impl From<std::option::NoneError> for HError {
+//     fn from(_error: std::option::NoneError) -> Self {
+//         let err = HError::NoneError;
+//         err
+//     }
+// }
 
 impl From<std::path::StripPrefixError> for HError {
     fn from(error: std::path::StripPrefixError) -> Self {

--- a/src/foldview.rs
+++ b/src/foldview.rs
@@ -180,7 +180,7 @@ impl FoldableWidgetExt for  ListView<Vec<LogEntry>> {
     }
 
     fn render_footer(&self) -> HResult<String> {
-        let current = self.current_fold()?;
+        let current = self.current_fold().ok_or_else(|| HError::NoneError)?;
         if let Some(logentry) = self.content.get(current) {
             let (xsize, ysize) = self.core.coordinates.size_u();
             let (_, ypos) = self.core.coordinates.position_u();
@@ -273,7 +273,7 @@ where
     Bindings<<ListView<Vec<F>> as ActingExt>::Action>: Default {
 
     pub fn toggle_fold(&mut self) -> HResult<()> {
-        let fold = self.current_fold()?;
+        let fold = self.current_fold().ok_or_else(|| HError::NoneError)?;
         let fold_pos = self.fold_start_pos(fold);
 
         self.content[fold].toggle_fold();

--- a/src/fscache.rs
+++ b/src/fscache.rs
@@ -203,9 +203,11 @@ impl FsCache {
         Ok(self.tab_settings
            .read()?
            .get(&dir)
-           .as_ref()?
+           .as_ref()
+           .ok_or_else(|| HError::NoneError)?
            .selection
-           .as_ref()?
+           .as_ref()
+           .ok_or_else(|| HError::NoneError)?
            .clone())
     }
 
@@ -367,7 +369,7 @@ impl FsCache {
         let dir = &files.directory;
         let tab_settings = cache.tab_settings.read()?.get(&dir).cloned();
         if tab_settings.is_none() { return Ok(()) }
-        let tab_settings = tab_settings?;
+        let tab_settings = tab_settings.ok_or_else(|| HError::NoneError)?;
 
         if files.show_hidden != tab_settings.dir_settings.show_hidden ||
             files.filter != tab_settings.dir_settings.filter ||
@@ -480,7 +482,7 @@ impl TryFrom<DebouncedEvent> for FsEvent {
             DebouncedEvent::Rescan
                 => Err(HError::INotifyError("Need to rescan".to_string()))?,
             // Ignore NoticeRemove/NoticeWrite
-            _ => None?,
+            _ => None.ok_or_else(|| HError::NoneError)?,
         };
 
         Ok(event)

--- a/src/hbox.rs
+++ b/src/hbox.rs
@@ -31,7 +31,7 @@ impl<T> HBox<T> where T: Widget + PartialEq {
 
         if self.zoom_active {
             let coords = self.core.coordinates.clone();
-            self.active_widget_mut()?.set_coordinates(&coords).log();
+            self.active_widget_mut().ok_or_else(|| HError::NoneError)?.set_coordinates(&coords).log();
             return Ok(());
         }
 
@@ -178,12 +178,12 @@ impl<T> Widget for HBox<T> where T: Widget + PartialEq {
     }
 
     fn render_header(&self) -> HResult<String> {
-        self.active_widget()?.render_header()
+        self.active_widget().ok_or_else(|| HError::NoneError)?.render_header()
     }
 
     fn refresh(&mut self) -> HResult<()> {
         if self.zoom_active {
-            self.active_widget_mut()?.refresh().log();
+            self.active_widget_mut().ok_or_else(|| HError::NoneError)?.refresh().log();
             return Ok(());
         }
 
@@ -196,7 +196,7 @@ impl<T> Widget for HBox<T> where T: Widget + PartialEq {
 
     fn get_drawlist(&self) -> HResult<String> {
         if self.zoom_active {
-            return self.active_widget()?.get_drawlist();
+            return self.active_widget().ok_or_else(|| HError::NoneError)?.get_drawlist();
         }
 
         Ok(self.widgets.iter().map(|child| {
@@ -205,11 +205,11 @@ impl<T> Widget for HBox<T> where T: Widget + PartialEq {
     }
 
     fn on_event(&mut self, event: Event) -> HResult<()> {
-        self.active_widget_mut()?.on_event(event)?;
+        self.active_widget_mut().ok_or_else(|| HError::NoneError)?.on_event(event)?;
         Ok(())
     }
 
     fn on_key(&mut self, key: termion::event::Key) -> HResult<()> {
-        self.active_widget_mut()?.on_key(key)
+        self.active_widget_mut().ok_or_else(|| HError::NoneError)?.on_key(key)
     }
 }

--- a/src/imgview.rs
+++ b/src/imgview.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::widget::{Widget, WidgetCore};
 use crate::coordinates::Coordinates;
-use crate::fail::{HResult, ErrorCause};
+use crate::fail::{HResult, ErrorCause, HError};
 use crate::mediaview::MediaError;
 
 
@@ -39,7 +39,7 @@ impl ImgView {
         let (xpix, ypix) = self.core.coordinates.size_pixels()?;
         let cell_ratio = crate::term::cell_ratio()?;
 
-        let file = &self.file.as_ref()?;
+        let file = &self.file.as_ref().ok_or_else(|| HError::NoneError)?;
         let media_previewer = self.core.config().media_previewer;
         let g_mode = self.core.config().graphics;
 

--- a/src/keybind.rs
+++ b/src/keybind.rs
@@ -396,7 +396,7 @@ where
     }
 
     fn parse_section(ini: &Ini) -> HResult<Bindings<Self>> {
-        let section = ini.section(Some(Self::section()))?;
+        let section = ini.section(Some(Self::section())).ok_or_else(|| HError::NoneError)?;
 
         let mut bindings = Bindings::new();
 

--- a/src/listview.rs
+++ b/src/listview.rs
@@ -545,13 +545,7 @@ impl ListView<Files>
         self.selected_file_mut().toggle_selection();
 
         if !self.content.filter_selected {
-            let oldpos = self.get_selection();
             self.move_down();
-            let newpos = self.get_selection();
-
-            if newpos > oldpos {
-                self.update_selected_file(oldpos);
-            }
         } else {
             if self.content.filter_selected && self.content.len() == 0 {
                 self.content.toggle_filter_selected();
@@ -654,7 +648,7 @@ impl ListView<Files>
         if self.searching.is_none() {
             self.core.show_status("No search pattern set!").log();
         }
-        let prev_search = self.searching.clone()?;
+        let prev_search = self.searching.clone().ok_or_else(|| HError::NoneError)?;
         let selection = self.get_selection();
 
         let file = self.content
@@ -682,7 +676,7 @@ impl ListView<Files>
         if self.searching.is_none() {
             self.core.show_status("No search pattern set!").log();
         }
-        let prev_search = self.searching.clone()?;
+        let prev_search = self.searching.clone().ok_or_else(|| HError::NoneError)?;
 
 
         self.reverse_sort();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![feature(vec_remove_item)]
-#![feature(trivial_bounds)]
-#![feature(try_trait)]
 #![allow(dead_code)]
 
 extern crate termion;

--- a/src/mediaview.rs
+++ b/src/mediaview.rs
@@ -157,8 +157,8 @@ impl MediaView {
                         MediaError::NoPreviewer(msg)
                     })?;
 
-                let mut stdout = BufReader::new(previewer.stdout.take()?);
-                let mut stdin = previewer.stdin.take()?;
+                let mut stdout = BufReader::new(previewer.stdout.take().ok_or_else(|| HError::NoneError)?);
+                let mut stdin = previewer.stdin.take().ok_or_else(|| HError::NoneError)?;
 
                 *cprocess.lock() = Some(previewer);
 
@@ -179,7 +179,8 @@ impl MediaView {
                 loop {
                     // Check if preview-gen finished and break out of loop to restart
                     if let Ok(Some(code)) = cprocess.lock()
-                                                    .as_mut()?
+                                                    .as_mut()
+                                                    .ok_or_else(|| HError::NoneError)?
                                                     .try_wait()
                     {
                         if code.success() {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -2,22 +2,22 @@ use dirs_2;
 
 use std::path::PathBuf;
 
-use crate::fail::HResult;
+use crate::fail::{HError, HResult};
 
 pub fn home_path() -> HResult<PathBuf> {
-    let home = dirs_2::home_dir()?;
+    let home = dirs_2::home_dir().ok_or_else(|| HError::NoneError)?;
     Ok(home)
 }
 
 pub fn ranger_path() -> HResult<PathBuf> {
-    let mut ranger_path = dirs_2::config_dir()?;
+    let mut ranger_path = dirs_2::config_dir().ok_or_else(|| HError::NoneError)?;
     ranger_path.push("ranger/");
     Ok(ranger_path)
 }
 
 #[cfg(not(target_os = "macos"))]
 pub fn hunter_path() -> HResult<PathBuf> {
-    let mut hunter_path = dirs_2::config_dir()?;
+    let mut hunter_path = dirs_2::config_dir().ok_or_else(|| HError::NoneError)?;
     hunter_path.push("hunter/");
     Ok(hunter_path)
 }

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use std::path::PathBuf;
 
-use crate::files::{File, Files, Kind, Ticker};
+use crate::files::{File, Files, Kind};
 use crate::fscache::FsCache;
 use crate::listview::{ListView, FileSource};
 use crate::textview::TextView;
@@ -76,6 +76,7 @@ impl<W: Widget + Send + 'static> AsyncWidget<W> {
         let mut widget = Async::new(move |stale|
                                     closure(stale).map_err(|e| e.into()));
         widget.on_ready(move |_, stale| {
+            crate::files::stop_ticking();
             if !stale.is_stale()? {
                 sender.lock()
                       .send(crate::widget::Events::WidgetReady)
@@ -85,6 +86,7 @@ impl<W: Widget + Send + 'static> AsyncWidget<W> {
             Ok(())
         }).log();
 
+        crate::files::start_ticking(core.get_sender());
         widget.run().log();
 
         AsyncWidget {
@@ -103,10 +105,11 @@ impl<W: Widget + Send + 'static> AsyncWidget<W> {
         let core = self.get_core()?.clone();
 
         let mut widget = Async::new(move |stale| {
-            Ok(closure(stale, core.clone())?)
+            Ok(closure(stale, closure_core)?)
         });
 
         widget.on_ready(move |_, stale| {
+            crate::files::stop_ticking();
             if !stale.is_stale()? {
                 sender.lock()
                       .send(crate::widget::Events::WidgetReady)
@@ -116,6 +119,7 @@ impl<W: Widget + Send + 'static> AsyncWidget<W> {
             Ok(())
         }).log();
 
+        crate::files::start_ticking(core.get_sender());
         widget.run().log();
 
         self.widget = widget;
@@ -234,7 +238,7 @@ enum ExtPreviewer {
 
 fn find_previewer(file: &File, g_mode: bool) -> HResult<ExtPreviewer> {
     let path = crate::paths::previewers_path()?;
-    let ext = file.path.extension()?;
+    let ext = file.path.extension().ok_or_else(|| HError::NoneError)?;
 
     // Try to find a graphical previewer first
     if g_mode {
@@ -273,7 +277,7 @@ fn find_previewer(file: &File, g_mode: bool) -> HResult<ExtPreviewer> {
         }
     }
 
-    Ok(ExtPreviewer::Text(previewer??))
+    Ok(ExtPreviewer::Text(previewer.ok_or_else(|| HError::NoneError)??))
 }
 
 
@@ -417,7 +421,6 @@ impl Previewer {
                         }
                         "image" if has_media => {
                             // Show animation while image is loading, Drop stops it automatically
-                            Ticker::start_ticking(core.get_sender());
                             let imgview = ImgView::new_from_file(core.clone(),
                                                                  &file.path())?;
                             return Ok(PreviewWidget::ImgView(imgview));
@@ -505,9 +508,6 @@ impl Previewer {
                     stale: &Stale,
                     animator: &Stale)
                     -> HResult<PreviewWidget> {
-        // Show animation while text is loading
-        let mut ticker = Ticker::start_ticking(core.get_sender());
-
         let lines = core.coordinates.ysize() as usize;
 
         let mut textview
@@ -521,8 +521,6 @@ impl Previewer {
 
         if stale.is_stale()? { return Previewer::preview_failed(&file) }
 
-        // Prevent flicker during slide up
-        ticker.stop_ticking();
         textview.animate_slide_up(Some(animator))?;
         Ok(PreviewWidget::TextView(textview))
     }
@@ -577,9 +575,6 @@ impl Previewer {
                         stale: &Stale,
                         animator: &Stale)
                         -> HResult<PreviewWidget> {
-        // Show animation while preview is being generated
-        let mut ticker = Ticker::start_ticking(core.get_sender());
-
         let previewer = if core.config().graphics.as_str() != "unicode" {
              find_previewer(&file, true)?
         } else {
@@ -596,15 +591,13 @@ impl Previewer {
                 textview.set_lines(lines)?;
                 textview.set_coordinates(&core.coordinates).log();
                 textview.refresh().log();
-                // Prevent flicker during slide up
-                ticker.stop_ticking();
                 textview.animate_slide_up(Some(animator)).log();
 
                 Ok(PreviewWidget::TextView(textview))
             },
             ExtPreviewer::Graphics(previewer) => {
                 let lines = Previewer::run_external(previewer, file, stale)?;
-                let gfile = lines.first()?;
+                let gfile = lines.first().ok_or_else(|| HError::NoneError)?;
                 let imgview = ImgView::new_from_file(core.clone(),
                                                      &PathBuf::from(&gfile))?;
                 Ok(PreviewWidget::ImgView(imgview))

--- a/src/preview.rs
+++ b/src/preview.rs
@@ -103,6 +103,7 @@ impl<W: Widget + Send + 'static> AsyncWidget<W> {
 
         let sender = Mutex::new(self.get_core()?.get_sender());
         let core = self.get_core()?.clone();
+        let closure_core = core.clone();
 
         let mut widget = Async::new(move |stale| {
             Ok(closure(stale, closure_core)?)

--- a/src/quick_actions.rs
+++ b/src/quick_actions.rs
@@ -61,7 +61,7 @@ impl FoldableWidgetExt for ListView<Vec<QuickActions>> {
     }
 
     fn render_header(&self) -> HResult<String> {
-        let mime = &self.content.get(0)?.mime;
+        let mime = &self.content.get(0).ok_or_else(|| HError::NoneError)?.mime;
         Ok(format!("QuickActions for MIME: {}", mime))
     }
 
@@ -154,7 +154,7 @@ impl ListView<Vec<QuickActions>> {
     fn run_action(&mut self, num: Option<usize>) -> HResult<()> {
         num.map(|num| self.set_selection(num));
 
-        let current_fold = self.current_fold()?;
+        let current_fold = self.current_fold().ok_or_else(|| HError::NoneError)?;
         let fold_start_pos = self.fold_start_pos(current_fold);
         let selection = self.get_selection();
         let selected_action_index = selection - fold_start_pos;
@@ -390,7 +390,7 @@ impl QuickAction {
                 }
             })?;
 
-        let cwd = files.get(0)?.parent_as_file()?;
+        let cwd = files.get(0).ok_or_else(|| HError::NoneError)?.parent_as_file()?;
 
         let files: Vec<OsString> = files.iter()
             .map(|f| OsString::from(&f.path))

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -4,7 +4,7 @@ use systemstat::data::Filesystem;
 use std::path::{Path, PathBuf, Component};
 use std::collections::HashMap;
 
-use crate::fail::{HResult, ErrorLog};
+use crate::fail::{HResult, ErrorLog, HError};
 
 #[derive(Debug,Clone)]
 pub struct FsStat {
@@ -52,7 +52,7 @@ impl FsStat {
                 }
                deepest
             });
-        let fs = self.stats.get(&deepest_match)?;
+        let fs = self.stats.get(&deepest_match).ok_or_else(|| HError::NoneError)?;
         Ok(fs)
     }
 }

--- a/src/tabview.rs
+++ b/src/tabview.rs
@@ -54,7 +54,7 @@ impl<T> TabView<T> where T: Widget, TabView<T>: Tabbable {
     }
 
     pub fn pop_widget(&mut self) -> HResult<T> {
-        let widget = self.widgets.pop()?;
+        let widget = self.widgets.pop().ok_or_else(|| HError::NoneError)?;
         if self.widgets.len() <= self.active {
             self.active -= 1;
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -9,7 +9,7 @@ use parse_ansi::parse_bytes;
 use crate::unicode_width::{UnicodeWidthStr, UnicodeWidthChar};
 use parking_lot::{Mutex, RwLock};
 
-use crate::fail::{HResult, ErrorLog};
+use crate::fail::{HResult, ErrorLog, HError};
 use crate::trait_ext::ExtractResult;
 
 pub type TermMode = AlternateScreen<RawTerminal<BufWriter<Stdout>>>;
@@ -52,7 +52,7 @@ impl Screen {
     }
 
     pub fn take_size(&self) -> HResult<(usize, usize)> {
-        Ok(self.size.write().take()?)
+        Ok(self.size.write().take().ok_or_else(|| HError::NoneError)?)
     }
 
     pub fn set_title(&mut self, title: &str) -> HResult<()> {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -139,7 +139,8 @@ impl WidgetCore {
     pub fn minibuffer_clear(&self) -> HResult<()> {
         self.minibuffer
             .lock()
-            .as_mut()?
+            .as_mut()
+            .ok_or_else(|| HError::NoneError)?
             .clear();
 
         Ok(())
@@ -148,7 +149,8 @@ impl WidgetCore {
     pub fn minibuffer(&self, query: &str) -> HResult<String> {
         let answer = self.minibuffer
             .lock()
-            .as_mut()?
+            .as_mut()
+            .ok_or_else(|| HError::NoneError)?
             .query(query, false);
         let mut screen = self.screen()?;
         screen.cursor_hide().log();
@@ -158,7 +160,8 @@ impl WidgetCore {
     pub fn minibuffer_continuous(&self, query: &str) -> HResult<String> {
         let answer = self.minibuffer
             .lock()
-            .as_mut()?
+            .as_mut()
+            .ok_or_else(|| HError::NoneError)?
             .query(query, true);
         let mut screen = self.screen()?;
         screen.cursor_hide().log();
@@ -452,7 +455,7 @@ pub trait Widget {
             self.set_coordinates(&ani_coords).log();
             let buffer = self.get_drawlist()?;
 
-            if !animator.as_ref()?.is_stale()? {
+            if !animator.as_ref().ok_or_else(|| HError::NoneError)?.is_stale()? {
                 self.get_core()?.write_to_screen(&buffer).log();
             }
 
@@ -476,7 +479,7 @@ pub trait Widget {
 
     fn handle_input(&mut self) -> HResult<()> {
         let (tx_internal_event, rx_internal_event) = channel();
-        let rx_global_event = self.get_core()?.event_receiver.lock().take()?;
+        let rx_global_event = self.get_core()?.event_receiver.lock().take().ok_or_else(|| HError::NoneError)?;
 
         dispatch_events(tx_internal_event, rx_global_event, self.get_core()?.screen()?);
 


### PR DESCRIPTION
Resolves #89
Closes #91

* Ported @bhavitsharma's changes without the big formatting overhaul.
* Fixed an ownership issue with core.

![image](https://user-images.githubusercontent.com/9866621/95271658-58712b80-0836-11eb-90db-625ec7050c2c.png)

For my fellow nix users, this is the `shell.nix` I was using:

```nix
let
  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
  nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
  ruststable = (nixpkgs.latest.rustChannels.stable.rust.override { extensions = [ "rust-src" "rls-preview" "rust-analysis" "rustfmt-preview" ];});
in
  with nixpkgs;
  stdenv.mkDerivation {
    name = "rust";
    buildInputs = [ openssl pkgconfig nasm rustup ruststable cmake zlib glibc glib gst_all_1.gstreamer gst_all_1.gst-plugins-base.dev gst_all_1.gst-plugins-bad.dev ];
  }

```

I didn't really think things through, just grabbed an existing `shell.nix` I had to hand and kept slapping on dependencies until `cargo`/`pkgconfig` stopped complaining.

@teto @magnetophon 
I wouldn't mind being added as a maintainer once either of you adds to nixpkgs :wink: 