### PR TITLE
fix E0599

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(vec_remove_item)]
 #![feature(trivial_bounds)]
 #![feature(try_trait)]
 #![allow(dead_code)]


### PR DESCRIPTION
error[E0599]: no method named `remove_item` found for struct `Vec<files::File>` in the current scope